### PR TITLE
Close rule coverage gaps and expand test suite (v1.8.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-react-19-upgrade",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "An ESLint plugin to identify and fix breaking changes when upgrading React 18 to React 19",
   "main": "index.js",
   "author": "Brett Farrow",

--- a/rules/no-factories.js
+++ b/rules/no-factories.js
@@ -58,13 +58,30 @@ function isLikelyReactModuleFactory(node) {
   return false;
 }
 
+function isRequireReact(node) {
+  return (
+    node &&
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === "require" &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === "Literal" &&
+    node.arguments[0].value === "react"
+  );
+}
+
+function isReactLikeObject(node) {
+  if (!node) return false;
+  if (node.type === "Identifier" && node.name === "React") return true;
+  return isRequireReact(node);
+}
+
 function isReactCreateFactoryMemberExpression(node) {
   return (
     node &&
     node.type === "MemberExpression" &&
     !node.computed &&
-    node.object.type === "Identifier" &&
-    node.object.name === "React" &&
+    isReactLikeObject(node.object) &&
     node.property.type === "Identifier" &&
     node.property.name === "createFactory"
   );
@@ -100,9 +117,7 @@ function resolvesToReactCreateFactory(context, node) {
 
   if (
     definitionNode.id.type === "ObjectPattern" &&
-    definitionNode.init &&
-    definitionNode.init.type === "Identifier" &&
-    definitionNode.init.name === "React"
+    isReactLikeObject(definitionNode.init)
   ) {
     return definitionNode.id.properties.some((property) => {
       if (property.type !== "Property" || property.computed) {

--- a/rules/no-legacy-context.js
+++ b/rules/no-legacy-context.js
@@ -17,35 +17,38 @@ module.exports = {
     hasSuggestions: true,
   },
   create(context) {
-    return {
-      "ClassDeclaration:exit"(node) {
-        node.body.body.forEach((member) => {
+    function checkClassBody(node) {
+      node.body.body.forEach((member) => {
+        if (
+          member.type === "ClassProperty" ||
+          member.type === "PropertyDefinition"
+        ) {
           if (
-            member.type === "ClassProperty" ||
-            member.type === "PropertyDefinition"
-          ) {
-            if (
-              member.key.name === "childContextTypes" ||
-              member.key.name === "contextTypes"
-            ) {
-              context.report({
-                node: member,
-                message: `'${member.key.name}' uses a legacy context API that is no longer supported in React 19. Use 'contextType' instead.`,
-              });
-            }
-          }
-          if (
-            member.type === "MethodDefinition" &&
-            member.key.name === "getChildContext"
+            member.key.name === "childContextTypes" ||
+            member.key.name === "contextTypes"
           ) {
             context.report({
               node: member,
-              message:
-                "'getChildContext' uses a legacy context API that is no longer supported in React 19. Use 'React.createContext()' instead.",
+              message: `'${member.key.name}' uses a legacy context API that is no longer supported in React 19. Use 'contextType' instead.`,
             });
           }
-        });
-      },
+        }
+        if (
+          member.type === "MethodDefinition" &&
+          member.key.name === "getChildContext"
+        ) {
+          context.report({
+            node: member,
+            message:
+              "'getChildContext' uses a legacy context API that is no longer supported in React 19. Use 'React.createContext()' instead.",
+          });
+        }
+      });
+    }
+
+    return {
+      "ClassDeclaration:exit": checkClassBody,
+      "ClassExpression:exit": checkClassBody,
     };
   },
 };

--- a/rules/no-prop-types.js
+++ b/rules/no-prop-types.js
@@ -1,7 +1,51 @@
 // rules/no-prop-types.js
+
+function getFilenameBase(context) {
+  const filename = context.filename ?? context.getFilename();
+  return filename
+    .split("/")
+    .pop()
+    .split("\\")
+    .pop()
+    .split(".")[0];
+}
+
+function getEnclosingClassName(node) {
+  let current = node.parent;
+
+  while (current) {
+    if (current.type === "ClassDeclaration" || current.type === "ClassExpression") {
+      if (current.id && current.id.type === "Identifier") {
+        return current.id.name;
+      }
+
+      if (
+        current.parent &&
+        current.parent.type === "VariableDeclarator" &&
+        current.parent.id.type === "Identifier"
+      ) {
+        return current.parent.id.name;
+      }
+
+      return "<anonymous>";
+    }
+
+    current = current.parent;
+  }
+
+  return "<anonymous>";
+}
+
+function isPropTypesKey(key) {
+  if (!key) return false;
+  if (key.type === "Identifier") return key.name === "propTypes";
+  if (key.type === "Literal") return key.value === "propTypes";
+  return false;
+}
+
 module.exports = {
   meta: {
-    type: "suggestion", // It's about potentially incorrect or outdated practices.
+    type: "suggestion",
     docs: {
       description: "Disallow the use of propTypes in React components",
       url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops",
@@ -12,7 +56,7 @@ module.exports = {
       propTypesImportDisallowed:
         "'prop-types' should not be imported in '{{name}}' as they are no longer supported in React 19.",
     },
-    schema: [], // No configuration options for this rule
+    schema: [],
     ruleId: "no-prop-types",
     hasSuggestions: true,
   },
@@ -20,36 +64,52 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         if (node.source.value === "prop-types") {
+          const name = getFilenameBase(context);
           node.specifiers.forEach((specifier) => {
-            const filename = context.filename ?? context.getFilename();
-            const name = filename
-              .split("/") // unix file paths
-              .pop()
-              .split("\\") // windows file paths
-              .pop()
-              .split(".")[0]; // remove extension
             context.report({
               node: specifier,
               messageId: "propTypesImportDisallowed",
-              data: {
-                name,
-              },
+              data: { name },
             });
+          });
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "require" &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === "Literal" &&
+          node.arguments[0].value === "prop-types"
+        ) {
+          context.report({
+            node,
+            messageId: "propTypesImportDisallowed",
+            data: { name: getFilenameBase(context) },
           });
         }
       },
       AssignmentExpression(node) {
         if (
           node.left.type === "MemberExpression" &&
+          !node.left.computed &&
           node.left.property.name === "propTypes" &&
           node.left.object.type === "Identifier" &&
           /^[A-Z]/.test(node.left.object.name)
         ) {
-          // Check if the object name starts with an uppercase letter
           context.report({
-            node: node,
+            node,
             messageId: "propTypesDisallowed",
             data: { name: node.left.object.name },
+          });
+        }
+      },
+      "ClassBody > PropertyDefinition, ClassBody > ClassProperty"(node) {
+        if (node.static && !node.computed && isPropTypesKey(node.key)) {
+          context.report({
+            node,
+            messageId: "propTypesDisallowed",
+            data: { name: getEnclosingClassName(node) },
           });
         }
       },

--- a/rules/no-string-refs.js
+++ b/rules/no-string-refs.js
@@ -15,14 +15,30 @@ module.exports = {
     hasSuggestions: true,
   },
   create(context) {
+    function report(node) {
+      context.report({ node, messageId: "noStringRefs" });
+    }
+
     return {
-      // JSX attribute inside a JSX element
-      "JSXAttribute[name.name='ref'][value.type='Literal']"(node) {
-        if (typeof node.value.value === "string") {
-          context.report({
-            node: node,
-            messageId: "noStringRefs",
-          });
+      "JSXAttribute[name.name='ref']"(node) {
+        const value = node.value;
+
+        if (!value) {
+          return;
+        }
+
+        if (value.type === "Literal" && typeof value.value === "string") {
+          report(node);
+          return;
+        }
+
+        if (
+          value.type === "JSXExpressionContainer" &&
+          value.expression &&
+          value.expression.type === "Literal" &&
+          typeof value.expression.value === "string"
+        ) {
+          report(node);
         }
       },
     };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,32 +1,37 @@
+const assert = require("assert");
 const { RuleTester } = require("eslint");
 const babelParser = require("@babel/eslint-parser");
+
+const plugin = require("../index.js");
 const ruleNoDefaultProps = require("../rules/no-default-props");
 const ruleNoPropTypes = require("../rules/no-prop-types");
 const ruleNoLegacyContext = require("../rules/no-legacy-context");
 const ruleNoStringRefs = require("../rules/no-string-refs");
 const ruleNoFactories = require("../rules/no-factories");
 
-const stats = { passed: 0, failed: 0, suites: [] };
+// --- minimal describe/it harness (mirrors prior style, prints a tree) ---
+
+const stats = { passed: 0, failed: 0 };
 let currentSuite = null;
 
-RuleTester.describe = function (text, method) {
+function describe(text, method) {
   const parent = currentSuite;
   const suite = { text, depth: parent ? parent.depth + 1 : 0 };
   currentSuite = suite;
   const indent = "  ".repeat(suite.depth);
   console.log(`${indent}${text}`);
   try {
-    method.call(this);
+    method();
   } finally {
     currentSuite = parent;
   }
-};
+}
 
-RuleTester.it = function (text, method) {
+function it(text, method) {
   const indent = "  ".repeat((currentSuite ? currentSuite.depth : 0) + 1);
   const label = text.length > 80 ? `${text.slice(0, 77)}...` : text;
   try {
-    method.call(this);
+    method();
     stats.passed += 1;
     console.log(`${indent}\u2713 ${label}`);
   } catch (err) {
@@ -34,11 +39,12 @@ RuleTester.it = function (text, method) {
     console.log(`${indent}\u2717 ${label}`);
     console.log(`${indent}  ${err.message.split("\n").join(`\n${indent}  `)}`);
   }
-};
+}
 
-RuleTester.itOnly = function (text, method) {
-  return RuleTester.it(text, method);
-};
+// RuleTester wires up to the same harness so its runs appear in the tree
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it;
 
 const ruleTester = new RuleTester({
   files: ["**/*.js", "**/*.mjs"],
@@ -49,290 +55,564 @@ const ruleTester = new RuleTester({
       babelOptions: {
         babelrc: false,
         configFile: false,
-        parserOpts: {
-          plugins: ["jsx", "classProperties"],
-        },
+        parserOpts: { plugins: ["jsx", "classProperties"] },
       },
-      ecmaFeatures: {
-        jsx: true,
-      },
+      ecmaFeatures: { jsx: true },
     },
   },
 });
 
-try {
-  // Test for "no-default-props"
-  ruleTester.run("no-default-props", ruleNoDefaultProps, {
-    valid: [
-      `const Component = ({ name }) => <div>{name}</div>;`,
-      `
+// -----------------------------------------------------------------------
+// 1. Plugin API surface
+// -----------------------------------------------------------------------
+
+describe("plugin api surface", () => {
+  it("exports a rules object", () => {
+    assert.ok(plugin && typeof plugin === "object", "plugin is an object");
+    assert.ok(plugin.rules && typeof plugin.rules === "object", "plugin.rules exists");
+  });
+
+  it("registers all five canonical rules", () => {
+    for (const name of [
+      "no-default-props",
+      "no-prop-types",
+      "no-legacy-context",
+      "no-string-refs",
+      "no-factories",
+    ]) {
+      assert.ok(plugin.rules[name], `rule ${name} is registered`);
+    }
+  });
+
+  it("exposes no-defaultprops / no-proptypes aliases pointing to the same rule", () => {
+    assert.strictEqual(plugin.rules["no-defaultprops"], plugin.rules["no-default-props"]);
+    assert.strictEqual(plugin.rules["no-proptypes"], plugin.rules["no-prop-types"]);
+  });
+
+  it("every rule has meta.type, meta.docs.url, meta.messages, and schema", () => {
+    for (const [name, rule] of Object.entries(plugin.rules)) {
+      assert.ok(rule.meta, `${name}.meta`);
+      assert.ok(
+        ["problem", "suggestion", "layout"].includes(rule.meta.type),
+        `${name}.meta.type is valid`,
+      );
+      assert.ok(rule.meta.docs && typeof rule.meta.docs.url === "string", `${name}.docs.url`);
+      assert.ok(rule.meta.messages && Object.keys(rule.meta.messages).length > 0, `${name}.messages`);
+      assert.ok(Array.isArray(rule.meta.schema), `${name}.schema is array`);
+      assert.strictEqual(typeof rule.create, "function", `${name}.create is function`);
+    }
+  });
+
+  it("every message template is a non-empty string", () => {
+    for (const [name, rule] of Object.entries(plugin.rules)) {
+      for (const [id, tpl] of Object.entries(rule.meta.messages)) {
+        assert.strictEqual(typeof tpl, "string", `${name}.${id}`);
+        assert.ok(tpl.length > 0, `${name}.${id} not empty`);
+      }
+    }
+  });
+
+  it("rule.create returns an object of AST visitors", () => {
+    const fakeContext = {
+      report: () => {},
+      getSourceCode: () => ({ getScope: () => ({ variables: [], upper: null }) }),
+      sourceCode: { getScope: () => ({ variables: [], upper: null }), getText: () => "" },
+      getFilename: () => "<input>",
+      filename: "<input>",
+      getScope: () => ({ variables: [], upper: null }),
+    };
+    for (const [name, rule] of Object.entries(plugin.rules)) {
+      const visitors = rule.create(fakeContext);
+      assert.ok(visitors && typeof visitors === "object", `${name}.create returns object`);
+      for (const fn of Object.values(visitors)) {
+        assert.strictEqual(typeof fn, "function", `${name} visitor is function`);
+      }
+    }
+  });
+});
+
+// -----------------------------------------------------------------------
+// 2. no-default-props
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-default-props", ruleNoDefaultProps, {
+  valid: [
+    // --- baseline shapes that should not fire ---
+    `const Component = ({ name }) => <div>{name}</div>;`,
+    `const Component = ({ name = 'x' }) => <div>{name}</div>;`,
+    `function Component({ name }) { return <div>{name}</div>; }`,
+
+    // class components — defaultProps is still legal on classes in React 19
+    `
       import { PureComponent } from 'react';
-
       class ClassComponent extends PureComponent {
-        render() {
-          const { propKey } = this.props;
-          return propKey;
-        }
+        render() { const { propKey } = this.props; return propKey; }
       }
+      ClassComponent.defaultProps = { propKey: 'propValue' };
+    `,
+    `
+      class C extends React.Component {
+        static defaultProps = { a: 1 };
+        render() { return null; }
+      }
+    `,
 
-      ClassComponent.defaultProps = {
-        propKey: 'propValue',
-      };
+    // assignment shapes the rule deliberately ignores
+    `foo.bar.defaultProps = { a: 1 };`,          // object not an Identifier
+    `Component.propTypes = { a: 1 };`,            // different property name
+    `Component.defaultProps = otherDefaults;`,    // right is not ObjectExpression
+    `Component["defaultProps"] = { a: 1 };`,      // computed member
+  ],
+  invalid: [
+    // --- simple arrow FC, single key, destructured + shorthand ---
+    {
+      code: `const Component = ({ name }) => <div>{name}</div>; Component.defaultProps = { name: 'Test' };`,
+      errors: [{ messageId: "defaultPropsDisallowed", data: { name: "Component" } }],
+      output: `const Component = ({ name = 'Test' }) => <div>{name}</div>; `,
+    },
+    // function declaration
+    {
+      code: `function Component({name}) { return <div>{name}</div>; } Component.defaultProps = { name: 'Test' };`,
+      errors: 1,
+      output: `function Component({ name = 'Test' }) { return <div>{name}</div>; } `,
+    },
+    // non-destructured (props) — reports, but no fix
+    {
+      code: `const Component = (props) => <div>{props.name}</div>; Component.defaultProps = { name: 'Test' };`,
+      errors: 1,
+      output: null,
+    },
+    // rest spread preserved
+    {
+      code: `const Component = ({ name, ...rest }) => <div>{name}</div>; Component.defaultProps = { name: 'Test' };`,
+      errors: 1,
+      output: `const Component = ({ name = 'Test', ...rest }) => <div>{name}</div>; `,
+    },
+    // renamed destructure
+    {
+      code: `const Component = ({ name: displayName }) => <div>{displayName}</div>; Component.defaultProps = { name: 'Test' };`,
+      errors: 1,
+      output: `const Component = ({ name: displayName = 'Test' }) => <div>{displayName}</div>; `,
+    },
+    // aliased via const
+    {
+      code: `const Component = ({ name }) => <div>{name}</div>; const Component2 = Component; Component2.defaultProps = { name: 'Test' };`,
+      errors: [{ messageId: "defaultPropsDisallowed", data: { name: "Component2" } }],
+      output: `const Component = ({ name = 'Test' }) => <div>{name}</div>; const Component2 = Component; `,
+    },
+    // aliased to an imported component — reports, but no fix (can't reach definition)
+    {
+      code: `import Component from './Component'; const Component2 = Component; Component2.defaultProps = { name: 'Test' };`,
+      errors: 1,
+    },
+    // wrapped by styled() — not a function component, reports without fix
+    {
+      code: "import Component from './Component'; const Component2 = styled(Component)``; Component2.defaultProps = { name: 'Test' };",
+      errors: 1,
+    },
+    // forwardRef wrapping — same: call expression, not a function/class node we can edit
+    {
+      code: `const C = React.forwardRef((props, ref) => <div />); C.defaultProps = { a: 1 };`,
+      errors: 1,
+      output: null,
+    },
+
+    // --- multi-key behavior ---
+    {
+      code: `const C = ({ a, b }) => <div>{a}{b}</div>; C.defaultProps = { a: 1, b: 2 };`,
+      errors: 1,
+      output: `const C = ({ a = 1, b = 2 }) => <div>{a}{b}</div>; `,
+    },
+    // key in defaults but not in destructure — appended to destructure
+    {
+      code: `const C = ({ a }) => <div />; C.defaultProps = { a: 1, b: 2 };`,
+      errors: 1,
+      output: `const C = ({ a = 1, b = 2 }) => <div />; `,
+    },
+    // key in destructure but not in defaults — left untouched
+    {
+      code: `const C = ({ a, b }) => <div />; C.defaultProps = { a: 1 };`,
+      errors: 1,
+      output: `const C = ({ a = 1, b }) => <div />; `,
+    },
+
+    // --- preservation of existing defaults ---
+    {
+      code: `const C = ({ a = 'keep' }) => <div />; C.defaultProps = { a: 'ignored' };`,
+      errors: 1,
+      output: `const C = ({ a = 'keep' }) => <div />; `,
+    },
+
+    // --- complex default expressions ---
+    {
+      code: `const C = ({ onClick }) => <button onClick={onClick} />; C.defaultProps = { onClick: () => {} };`,
+      errors: 1,
+      output: `const C = ({ onClick = () => {} }) => <button onClick={onClick} />; `,
+    },
+    {
+      code: `const DEFAULT = 'hi'; const C = ({ name }) => <div>{name}</div>; C.defaultProps = { name: DEFAULT };`,
+      errors: 1,
+      output: `const DEFAULT = 'hi'; const C = ({ name = DEFAULT }) => <div>{name}</div>; `,
+    },
+
+    // --- non-fixable due to unsafe key shape ---
+    {
+      code: "const C = ({ a }) => <div />; C.defaultProps = { a: 1, 'data-x': 2 };",
+      errors: 1,
+      output: null,
+    },
+
+    // --- empty defaults — reports, fix collapses the assignment ---
+    {
+      code: `const C = ({ a }) => <div />; C.defaultProps = {};`,
+      errors: 1,
+      output: `const C = ({ a }) => <div />; `,
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 3. no-prop-types
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-prop-types", ruleNoPropTypes, {
+  valid: [
+    `const Component = ({ name }) => <div>{name}</div>;`,
+    `import Something from 'not-prop-types';`,
+    `const other = require('not-prop-types');`,              // different module
+    `foo.propTypes = { a: 1 };`,                             // lowercase identifier guarded
+    `this.propTypes = { a: 1 };`,                            // ThisExpression, not Identifier
+    `class C { propTypes = { a: 1 }; }`,                     // instance field, not static
+  ],
+  invalid: [
+    {
+      code: `
+        import PropTypes from 'prop-types';
+        const Component = ({ name }) => <div>{name}</div>;
+        Component.propTypes = { name: PropTypes.string };
       `,
-    ],
-    invalid: [
-      {
-        code: `const Component = ({ name }) => <div>{name}</div>; Component.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-        output: `const Component = ({ name = 'Test' }) => <div>{name}</div>; `,
-      },
-      {
-        code: `function Component({name}) { return <div>{name}</div>; } Component.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-        output: `function Component({ name = 'Test' }) { return <div>{name}</div>; } `,
-      },
-      {
-        code: `const Component = (props) => <div>{props.name}</div>; Component.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-        output: null,
-      },
-      {
-        code: `const Component = ({ name, ...rest }) => <div>{name}</div>; Component.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-        output: `const Component = ({ name = 'Test', ...rest }) => <div>{name}</div>; `,
-      },
-      {
-        code: `const Component = ({ name: displayName }) => <div>{displayName}</div>; Component.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-        output: `const Component = ({ name: displayName = 'Test' }) => <div>{displayName}</div>; `,
-      },
-      {
-        code: `const Component = ({ name }) => <div>{name}</div>; const Component2 = Component; Component2.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component2' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-        output: `const Component = ({ name = 'Test' }) => <div>{name}</div>; const Component2 = Component; `,
-      },
-      {
-        code: `import Component from './Component'; const Component2 = Component; Component2.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component2' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-      },
-      {
-        code: `import Component from './Component'; const Component2 = styled(Component)\`\`; Component2.defaultProps = { name: 'Test' };`,
-        errors: [
-          {
-            message:
-              "'defaultProps' should not be used in 'Component2' as they are no longer supported in React 19. Use default parameters instead.",
-          },
-        ],
-      },
-    ],
-  });
-
-  // Test for "no-prop-types"
-  ruleTester.run("no-prop-types", ruleNoPropTypes, {
-    valid: [`const Component = ({ name }) => <div>{name}</div>;`],
-    invalid: [
-      {
-        code: `import PropTypes from 'prop-types';
-        
+      errors: [
+        { messageId: "propTypesImportDisallowed" },
+        { messageId: "propTypesDisallowed", data: { name: "Component" } },
+      ],
+    },
+    {
+      code: `
+        import PT from 'prop-types';
         const Component = ({ name }) => <div>{name}</div>;
-        
-        Component.propTypes = { name: PropTypes.string };`,
-        errors: [
-          {
-            message:
-              "'prop-types' should not be imported in '<input>' as they are no longer supported in React 19.",
-            type: "ImportDefaultSpecifier", // TODO: This is an ImportDeclaration in the code, determine why that type isn't returned
-          },
-          {
-            message:
-              "'propTypes' should not be used in 'Component' as they are no longer supported in React 19.",
-            type: "AssignmentExpression",
-          },
-        ],
-      },
-      {
-        code: `import PT from 'prop-types';
+        Component.propTypes = { name: PT.string };
+      `,
+      errors: [
+        { messageId: "propTypesImportDisallowed" },
+        { messageId: "propTypesDisallowed" },
+      ],
+    },
+    {
+      code: `import { bool, string } from 'prop-types';`,
+      errors: [
+        { messageId: "propTypesImportDisallowed" },
+        { messageId: "propTypesImportDisallowed" },
+      ],
+    },
+    {
+      code: `import * as PT from 'prop-types';`,
+      errors: [{ messageId: "propTypesImportDisallowed" }],
+    },
+    // propTypes assignment without any import — still flagged
+    {
+      code: `Component.propTypes = { a: 1 };`,
+      errors: [{ messageId: "propTypesDisallowed" }],
+    },
+    // CommonJS require of prop-types
+    {
+      code: `const PropTypes = require('prop-types');`,
+      errors: [{ messageId: "propTypesImportDisallowed" }],
+    },
+    // static propTypes class field on a class declaration
+    {
+      code: `class Component { static propTypes = { a: 1 }; }`,
+      errors: [{ messageId: "propTypesDisallowed", data: { name: "Component" } }],
+    },
+    // static propTypes on a class expression (uses binding name)
+    {
+      code: `const Component = class { static propTypes = { a: 1 }; };`,
+      errors: [{ messageId: "propTypesDisallowed", data: { name: "Component" } }],
+    },
+    // multiple components in one file
+    {
+      code: `
+        import PropTypes from 'prop-types';
+        const A = () => null;
+        const B = () => null;
+        A.propTypes = { x: PropTypes.string };
+        B.propTypes = { y: PropTypes.number };
+      `,
+      errors: [
+        { messageId: "propTypesImportDisallowed" },
+        { messageId: "propTypesDisallowed", data: { name: "A" } },
+        { messageId: "propTypesDisallowed", data: { name: "B" } },
+      ],
+    },
+  ],
+});
 
-        const Component = ({ name }) => <div>{name}</div>;
+// -----------------------------------------------------------------------
+// 4. no-legacy-context
+// -----------------------------------------------------------------------
 
-        Component.propTypes = { name: PT.string };`,
-        errors: [
-          {
-            message:
-              "'prop-types' should not be imported in '<input>' as they are no longer supported in React 19.",
-            type: "ImportDefaultSpecifier",
-          },
-          {
-            message:
-              "'propTypes' should not be used in 'Component' as they are no longer supported in React 19.",
-            type: "AssignmentExpression",
-          },
-        ],
-      },
-    ],
-  });
-
-  // Tests for "no-legacy-context"
-  ruleTester.run("no-legacy-context", ruleNoLegacyContext, {
-    valid: [
-      // Example of a class component that does not use legacy context APIs
-      `
+ruleTester.run("no-legacy-context", ruleNoLegacyContext, {
+  valid: [
+    `
       class MyComponent extends React.Component {
-        render() {
-          return <div>{this.props.children}</div>;
-        }
+        render() { return <div>{this.props.children}</div>; }
       }
-      `,
-      // Using the new context API
-      `
+    `,
+    // modern context API
+    `
       const MyContext = React.createContext();
       class MyComponent extends React.Component {
         static contextType = MyContext;
-        render() {
-          return <div>{this.context}</div>;
-        }
+        render() { return <div>{this.context}</div>; }
       }
-      `,
-    ],
-    invalid: [
-      {
-        code: `
+    `,
+    // similarly-named, unrelated members
+    `
+      class C extends React.Component {
+        static myContextTypes = { a: 1 };
+        getContext() { return {}; }
+        render() { return null; }
+      }
+    `,
+  ],
+  invalid: [
+    // the full triple from the original suite
+    {
+      code: `
         import PropTypes from 'prop-types';
-
         class Parent extends React.Component {
-          static childContextTypes = {
-            foo: PropTypes.string.isRequired,
-          };
-
-          getChildContext() {
-            return { foo: 'bar' };
-          }
-
-          render() {
-            return <Child />;
-          }
+          static childContextTypes = { foo: PropTypes.string.isRequired };
+          getChildContext() { return { foo: 'bar' }; }
+          render() { return <Child />; }
         }
-
         class Child extends React.Component {
-          static contextTypes = {
-            foo: PropTypes.string.isRequired,
-          };
-
-          render() {
-            return <div>{this.context.foo}</div>;
-          }
+          static contextTypes = { foo: PropTypes.string.isRequired };
+          render() { return <div>{this.context.foo}</div>; }
         }
-        `,
-        errors: [
-          {
-            message:
-              "'childContextTypes' uses a legacy context API that is no longer supported in React 19. Use 'contextType' instead.",
-          },
-          {
-            message:
-              "'getChildContext' uses a legacy context API that is no longer supported in React 19. Use 'React.createContext()' instead.",
-          },
-          {
-            message:
-              "'contextTypes' uses a legacy context API that is no longer supported in React 19. Use 'contextType' instead.",
-          },
-        ],
-      },
-    ],
-  });
-
-  // Test for "no-string-refs"
-  ruleTester.run("no-string-refs", ruleNoStringRefs, {
-    valid: [
-      {
-        code: `<input ref={(input) => this.input = input} />`,
-      },
-    ],
-    invalid: [
-      {
-        code: `<input ref='input' />`,
-        errors: [{ messageId: "noStringRefs", type: "JSXAttribute" }],
-      },
-    ],
-  });
-
-  ruleTester.run("no-factories", ruleNoFactories, {
-    valid: [
-      `function FactoryComponent() { return <div />; }`,
-      `const button = <button />;`,
-    ],
-    invalid: [
-      {
-        code: `function FactoryComponent() { return { render() { return <div />; } } }`,
-        errors: [{ messageId: "noModulePattern" }],
-      },
-      {
-        code: `import { createFactory } from 'react'; const divFactory = createFactory('div');`,
-        errors: [{ messageId: "noCreateFactory" }],
-      },
-      {
-        code: `const createFactory = React.createFactory; const divFactory = createFactory('div');`,
-        errors: [{ messageId: "noCreateFactory" }],
-      },
-    ],
-  });
-
-  ruleTester.run("no-factories false positives", ruleNoFactories, {
-    valid: [
-      `
-      function notReact() {
-        return {
-          render: function() {
-            return value;
-          }
-        };
-      }
       `,
-    ],
-    invalid: [],
-  });
+      errors: [
+        { message: "'childContextTypes' uses a legacy context API that is no longer supported in React 19. Use 'contextType' instead." },
+        { message: "'getChildContext' uses a legacy context API that is no longer supported in React 19. Use 'React.createContext()' instead." },
+        { message: "'contextTypes' uses a legacy context API that is no longer supported in React 19. Use 'contextType' instead." },
+      ],
+    },
+    // contextTypes alone
+    {
+      code: `
+        class C extends React.Component {
+          static contextTypes = { a: 1 };
+          render() { return null; }
+        }
+      `,
+      errors: 1,
+    },
+    // childContextTypes alone
+    {
+      code: `
+        class C extends React.Component {
+          static childContextTypes = { a: 1 };
+          render() { return null; }
+        }
+      `,
+      errors: 1,
+    },
+    // getChildContext alone
+    {
+      code: `
+        class C extends React.Component {
+          getChildContext() { return {}; }
+          render() { return null; }
+        }
+      `,
+      errors: 1,
+    },
+    // instance (non-static) class field — rule still catches these
+    {
+      code: `
+        class C extends React.Component {
+          contextTypes = { a: 1 };
+          render() { return null; }
+        }
+      `,
+      errors: 1,
+    },
+    // class expression with legacy context — also caught
+    {
+      code: `
+        const C = class extends React.Component {
+          static contextTypes = { a: 1 };
+          getChildContext() { return {}; }
+          render() { return null; }
+        };
+      `,
+      errors: 2,
+    },
+  ],
+});
 
-  console.log(`\n${stats.passed} passed, ${stats.failed} failed`);
-  if (stats.failed > 0) {
-    process.exitCode = 1;
-  }
-} catch (error) {
-  console.error(error);
-  console.error("One or more tests failed!");
+// -----------------------------------------------------------------------
+// 5. no-string-refs
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-string-refs", ruleNoStringRefs, {
+  valid: [
+    // callback ref
+    { code: `<input ref={(input) => this.input = input} />` },
+    // object ref from useRef
+    { code: `const r = useRef(null); return <input ref={r} />;` },
+    // null ref
+    { code: `<input ref={null} />` },
+    // numeric in expression container
+    { code: `<input ref={42} />` },
+    // no ref attribute at all
+    { code: `<input type="text" />` },
+    // template literal (not a Literal node) — bypasses the rule by design
+    { code: "<input ref={`dyn`} />" },
+  ],
+  invalid: [
+    {
+      code: `<input ref='input' />`,
+      errors: [{ messageId: "noStringRefs", type: "JSXAttribute" }],
+    },
+    // double-quoted
+    {
+      code: `<input ref="input" />`,
+      errors: [{ messageId: "noStringRefs" }],
+    },
+    // empty string literal in attribute position
+    {
+      code: `<input ref="" />`,
+      errors: [{ messageId: "noStringRefs" }],
+    },
+    // string literal wrapped in a JSXExpressionContainer
+    {
+      code: `<input ref={"input"} />`,
+      errors: [{ messageId: "noStringRefs" }],
+    },
+    {
+      code: `<input ref={""} />`,
+      errors: [{ messageId: "noStringRefs" }],
+    },
+    // nested JSX
+    {
+      code: `<div><input ref="inner" /></div>`,
+      errors: [{ messageId: "noStringRefs" }],
+    },
+    // inside a map
+    {
+      code: `items.map(i => <input key={i} ref="x" />);`,
+      errors: [{ messageId: "noStringRefs" }],
+    },
+    // multiple string refs in one file — each reported
+    {
+      code: `<div><input ref="a" /><input ref="b" /></div>`,
+      errors: [
+        { messageId: "noStringRefs" },
+        { messageId: "noStringRefs" },
+      ],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 6. no-factories
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-factories", ruleNoFactories, {
+  valid: [
+    `function FactoryComponent() { return <div />; }`,
+    `const button = <button />;`,
+    // lowercase function returning an object with render — not a React factory
+    `
+      function notReact() {
+        return { render: function() { return value; } };
+      }
+    `,
+    // lowercase const assigned a factory-like object — not flagged
+    `
+      const helper = function() {
+        return { render: function() { return null; } };
+      };
+    `,
+    // uppercase but no render method — not the module-factory pattern
+    `
+      function Config() {
+        return { foo: 1, bar: 2 };
+      }
+    `,
+    // createFactory imported from a different package — not flagged
+    `import { createFactory } from 'other'; const d = createFactory('div');`,
+    // destructure from a require() of a different package
+    `const { createFactory } = require('other'); const d = createFactory('div');`,
+  ],
+  invalid: [
+    // classic module-pattern factory
+    {
+      code: `function FactoryComponent() { return { render() { return <div />; } } }`,
+      errors: [{ messageId: "noModulePattern" }],
+    },
+    // uppercase arrow / function expression assigned to const
+    {
+      code: `const Foo = function() { return { render: function() { return null; } }; };`,
+      errors: [{ messageId: "noModulePattern" }],
+    },
+    // named import of createFactory from react
+    {
+      code: `import { createFactory } from 'react'; const divFactory = createFactory('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // aliased React.createFactory
+    {
+      code: `const createFactory = React.createFactory; const divFactory = createFactory('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // destructured from React (identifier, not via require)
+    {
+      code: `const { createFactory } = React; const d = createFactory('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // renamed destructure — tracked via property key matching
+    {
+      code: `const { createFactory: cf } = React; const d = cf('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // direct React.createFactory call without any alias
+    {
+      code: `const d = React.createFactory('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // destructure from require('react')
+    {
+      code: `const { createFactory } = require('react'); const d = createFactory('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // renamed destructure from require('react')
+    {
+      code: `const { createFactory: cf } = require('react'); const d = cf('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+    // direct require('react').createFactory(...) call
+    {
+      code: `const d = require('react').createFactory('div');`,
+      errors: [{ messageId: "noCreateFactory" }],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// summary
+// -----------------------------------------------------------------------
+
+console.log(`\n${stats.passed} passed, ${stats.failed} failed`);
+if (stats.failed > 0) {
   process.exitCode = 1;
 }


### PR DESCRIPTION
## Summary

Expands the test suite from 24 to 87 cases, which surfaced five real coverage gaps in the rules. All fixes cause the rules to flag patterns they previously ignored — per ESLint's own versioning convention, that makes this a **MINOR** bump (`1.7.1 → 1.8.0`).

### Rule fixes

- **`no-string-refs`** — previously only matched `JSXAttribute[value.type='Literal']`, so `ref={"input"}` (a string literal wrapped in a `JSXExpressionContainer`) slipped through. Now handles both attribute forms.
- **`no-legacy-context`** — visitor was `ClassDeclaration:exit` only; the scan now runs on `ClassExpression:exit` too, so `const C = class extends React.Component { static contextTypes = {...} }` is caught.
- **`no-prop-types`** — added a `CallExpression` visitor for `require('prop-types')` and a `ClassBody > PropertyDefinition/ClassProperty` visitor for static `propTypes` fields. The class-name lookup walks up through a `VariableDeclarator` for class-expression bindings.
- **`no-factories`** — new `isRequireReact` / `isReactLikeObject` helpers so `require('react').createFactory(...)`, `const { createFactory } = require('react')`, and the renamed form are flagged alongside the existing `React.*` patterns.

### Test surface

- New `plugin api surface` suite: exports shape, all five canonical rule names plus the `no-defaultprops`/`no-proptypes` aliases, rule meta validity, non-empty message templates, visitor shape.
- Per-rule valid/invalid coverage now exercises guard branches (non-ObjectExpression RHS, computed members, lowercase identifiers, `this.propTypes`, non-React lowercase factories, non-`prop-types` require, etc.) and every fixable vs. non-fixable path for `no-default-props` (multi-key, missing-key insertion, preserved defaults, `forwardRef`/`styled` wrappers, non-identifier default keys, empty defaults).
