### PR TITLE
add legacy React 19 upgrade rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ Then configure the rules you want to use under the rules section.
     "react-19-upgrade/no-prop-types": "warn",
     "react-19-upgrade/no-legacy-context": "error",
     "react-19-upgrade/no-string-refs": "error",
-    "react-19-upgrade/no-factories": "error"
+    "react-19-upgrade/no-factories": "error",
+    "react-19-upgrade/no-legacy-react-dom": "error",
+    "react-19-upgrade/no-legacy-react-dom-server": "error",
+    "react-19-upgrade/no-legacy-test-utils-act": "error"
   }
 }
 ```
@@ -52,3 +55,10 @@ Then configure the rules you want to use under the rules section.
 - `no-legacy-context`: Disallow the use of legacy context APIs in React class components.
 - `no-string-refs`: Disallow the use of string refs in React components.
 - `no-factories`: Disallow module pattern factories and React.createFactory.
+- `no-legacy-react-dom`: Disallow removed `react-dom` APIs (`render`, `hydrate`, `unmountComponentAtNode`, `findDOMNode`). Use `createRoot`/`hydrateRoot` from `react-dom/client`, or refs, instead.
+- `no-legacy-react-dom-server`: Disallow `renderToNodeStream` and `renderToStaticNodeStream` from `react-dom/server`. Use `renderToPipeableStream` instead (note: different signature).
+- `no-legacy-test-utils-act`: Import `act` from `react`, not `react-dom/test-utils`. Fixable by ESLint.
+
+### `element.ref` access
+
+React 19 makes `ref` a regular prop, so `element.ref` becomes `element.props.ref`. This plugin does not lint for it — any sound static heuristic either misses real cases or produces false positives on valid code. Use the official React codemod instead: `npx codemod@latest react/19/replace-ref-access`.

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = {
     "no-legacy-context": require("./rules/no-legacy-context"),
     "no-string-refs": require("./rules/no-string-refs"),
     "no-factories": require("./rules/no-factories"),
+    "no-legacy-react-dom": require("./rules/no-legacy-react-dom"),
+    "no-legacy-react-dom-server": require("./rules/no-legacy-react-dom-server"),
+    "no-legacy-test-utils-act": require("./rules/no-legacy-test-utils-act"),
     // equivalent but without the extra dash
     "no-defaultprops": require("./rules/no-default-props"),
     "no-proptypes": require("./rules/no-prop-types"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-react-19-upgrade",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-react-19-upgrade",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-react-19-upgrade",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "An ESLint plugin to identify and fix breaking changes when upgrading React 18 to React 19",
   "main": "index.js",
   "author": "Brett Farrow",

--- a/rules/no-legacy-react-dom-server.js
+++ b/rules/no-legacy-react-dom-server.js
@@ -1,0 +1,142 @@
+// rules/no-legacy-react-dom-server.js
+
+const SOURCE = "react-dom/server";
+
+const REMOVED_APIS = {
+  renderToNodeStream: "noRenderToNodeStream",
+  renderToStaticNodeStream: "noRenderToStaticNodeStream",
+};
+
+function findVariable(scope, name) {
+  let currentScope = scope;
+
+  while (currentScope) {
+    const variable = currentScope.variables.find((item) => item.name === name);
+
+    if (variable) {
+      return variable;
+    }
+
+    currentScope = currentScope.upper;
+  }
+
+  return null;
+}
+
+function isRequireSource(node) {
+  return (
+    node &&
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === "require" &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === "Literal" &&
+    node.arguments[0].value === SOURCE
+  );
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow 'renderToNodeStream' and 'renderToStaticNodeStream' from 'react-dom/server' (removed in React 19)",
+      url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
+    },
+    messages: {
+      noRenderToNodeStream:
+        "'renderToNodeStream' is removed in React 19. Use 'renderToPipeableStream' from 'react-dom/server' (note: different signature).",
+      noRenderToStaticNodeStream:
+        "'renderToStaticNodeStream' is removed in React 19. Use 'renderToPipeableStream' from 'react-dom/server' (note: different signature).",
+    },
+    schema: [],
+    ruleId: "no-legacy-react-dom-server",
+    hasSuggestions: true,
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const namespaceVariables = new Set();
+
+    function trackNamespace(node) {
+      const [variable] = sourceCode.getDeclaredVariables(node);
+
+      if (variable) {
+        namespaceVariables.add(variable);
+      }
+    }
+
+    function isTrackedNamespaceIdentifier(node) {
+      const scope = sourceCode.getScope
+        ? sourceCode.getScope(node)
+        : context.getScope();
+      const variable = findVariable(scope, node.name);
+
+      return Boolean(variable && namespaceVariables.has(variable));
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== SOURCE) return;
+
+        for (const spec of node.specifiers) {
+          if (spec.type === "ImportSpecifier") {
+            const imported = spec.imported && spec.imported.name;
+            const messageId = REMOVED_APIS[imported];
+            if (messageId) {
+              context.report({ node: spec, messageId });
+            }
+          } else if (
+            spec.type === "ImportDefaultSpecifier" ||
+            spec.type === "ImportNamespaceSpecifier"
+          ) {
+            trackNamespace(spec);
+          }
+        }
+      },
+
+      VariableDeclarator(node) {
+        if (!isRequireSource(node.init)) return;
+
+        if (node.id.type === "Identifier") {
+          trackNamespace(node);
+          return;
+        }
+
+        if (node.id.type === "ObjectPattern") {
+          for (const property of node.id.properties) {
+            if (property.type !== "Property" || property.computed) continue;
+
+            const keyName =
+              property.key.type === "Identifier"
+                ? property.key.name
+                : property.key.value;
+
+            const messageId = REMOVED_APIS[keyName];
+            if (messageId) {
+              context.report({ node: property, messageId });
+            }
+          }
+        }
+      },
+
+      MemberExpression(node) {
+        if (node.computed || node.property.type !== "Identifier") return;
+
+        const messageId = REMOVED_APIS[node.property.name];
+        if (!messageId) return;
+
+        if (
+          node.object.type === "Identifier" &&
+          isTrackedNamespaceIdentifier(node.object)
+        ) {
+          context.report({ node, messageId });
+          return;
+        }
+
+        if (isRequireSource(node.object)) {
+          context.report({ node, messageId });
+        }
+      },
+    };
+  },
+};

--- a/rules/no-legacy-react-dom.js
+++ b/rules/no-legacy-react-dom.js
@@ -1,0 +1,155 @@
+// rules/no-legacy-react-dom.js
+
+const SOURCE = "react-dom";
+
+const REMOVED_APIS = {
+  render: "noRender",
+  hydrate: "noHydrate",
+  unmountComponentAtNode: "noUnmountComponentAtNode",
+  findDOMNode: "noFindDOMNode",
+};
+
+function findVariable(scope, name) {
+  let currentScope = scope;
+
+  while (currentScope) {
+    const variable = currentScope.variables.find((item) => item.name === name);
+
+    if (variable) {
+      return variable;
+    }
+
+    currentScope = currentScope.upper;
+  }
+
+  return null;
+}
+
+function isRequireReactDom(node) {
+  return (
+    node &&
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === "require" &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === "Literal" &&
+    node.arguments[0].value === SOURCE
+  );
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow ReactDOM.render, hydrate, unmountComponentAtNode, and findDOMNode (removed in React 19)",
+      url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
+    },
+    messages: {
+      noRender:
+        "'ReactDOM.render' is removed in React 19. Import 'createRoot' from 'react-dom/client' and call 'createRoot(container).render(element)' instead.",
+      noHydrate:
+        "'ReactDOM.hydrate' is removed in React 19. Import 'hydrateRoot' from 'react-dom/client' and call 'hydrateRoot(container, element)' instead.",
+      noUnmountComponentAtNode:
+        "'ReactDOM.unmountComponentAtNode' is removed in React 19. Hold on to the root returned by 'createRoot' and call 'root.unmount()' instead.",
+      noFindDOMNode:
+        "'ReactDOM.findDOMNode' is removed in React 19. Attach a ref to the DOM node you need instead.",
+    },
+    schema: [],
+    ruleId: "no-legacy-react-dom",
+    hasSuggestions: true,
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const namespaceVariables = new Set();
+
+    function reportApi(node, apiName) {
+      const messageId = REMOVED_APIS[apiName];
+      if (!messageId) return;
+      context.report({ node, messageId });
+    }
+
+    function trackNamespace(node) {
+      const [variable] = sourceCode.getDeclaredVariables(node);
+
+      if (variable) {
+        namespaceVariables.add(variable);
+      }
+    }
+
+    function isTrackedNamespaceIdentifier(node) {
+      const scope = sourceCode.getScope
+        ? sourceCode.getScope(node)
+        : context.getScope();
+      const variable = findVariable(scope, node.name);
+
+      return Boolean(variable && namespaceVariables.has(variable));
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== SOURCE) return;
+
+        for (const spec of node.specifiers) {
+          if (spec.type === "ImportSpecifier") {
+            if (spec.imported && REMOVED_APIS[spec.imported.name]) {
+              context.report({
+                node: spec,
+                messageId: REMOVED_APIS[spec.imported.name],
+              });
+            }
+          } else if (
+            spec.type === "ImportDefaultSpecifier" ||
+            spec.type === "ImportNamespaceSpecifier"
+          ) {
+            trackNamespace(spec);
+          }
+        }
+      },
+
+      VariableDeclarator(node) {
+        if (!isRequireReactDom(node.init)) return;
+
+        if (node.id.type === "Identifier") {
+          trackNamespace(node);
+          return;
+        }
+
+        if (node.id.type === "ObjectPattern") {
+          for (const property of node.id.properties) {
+            if (property.type !== "Property" || property.computed) continue;
+
+            const keyName =
+              property.key.type === "Identifier"
+                ? property.key.name
+                : property.key.value;
+
+            if (!REMOVED_APIS[keyName]) continue;
+            context.report({ node: property, messageId: REMOVED_APIS[keyName] });
+          }
+        }
+      },
+
+      MemberExpression(node) {
+        if (node.computed || node.property.type !== "Identifier") {
+          return;
+        }
+
+        const apiName = node.property.name;
+        if (!REMOVED_APIS[apiName]) return;
+
+        if (
+          node.object.type === "Identifier" &&
+          isTrackedNamespaceIdentifier(node.object)
+        ) {
+          reportApi(node, apiName);
+          return;
+        }
+
+        if (isRequireReactDom(node.object)) {
+          reportApi(node, apiName);
+        }
+      },
+    };
+  },
+};

--- a/rules/no-legacy-test-utils-act.js
+++ b/rules/no-legacy-test-utils-act.js
@@ -1,0 +1,203 @@
+// rules/no-legacy-test-utils-act.js
+
+const SOURCE = "react-dom/test-utils";
+
+function findVariable(scope, name) {
+  let currentScope = scope;
+
+  while (currentScope) {
+    const variable = currentScope.variables.find((item) => item.name === name);
+
+    if (variable) {
+      return variable;
+    }
+
+    currentScope = currentScope.upper;
+  }
+
+  return null;
+}
+
+function isRequireTestUtils(node) {
+  return (
+    node &&
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === "require" &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === "Literal" &&
+    node.arguments[0].value === SOURCE
+  );
+}
+
+function specifierToText(spec) {
+  if (spec.type !== "ImportSpecifier") return null;
+  if (spec.local.name === spec.imported.name) {
+    return spec.imported.name;
+  }
+  return `${spec.imported.name} as ${spec.local.name}`;
+}
+
+function rebuildImport(specs, source, quote) {
+  const defaults = specs.filter((s) => s.type === "ImportDefaultSpecifier");
+  const namespaces = specs.filter((s) => s.type === "ImportNamespaceSpecifier");
+  const named = specs.filter((s) => s.type === "ImportSpecifier");
+
+  const parts = [];
+  if (defaults.length) parts.push(defaults[0].local.name);
+  if (namespaces.length) parts.push(`* as ${namespaces[0].local.name}`);
+  if (named.length) {
+    parts.push(`{ ${named.map(specifierToText).join(", ")} }`);
+  }
+
+  return `import ${parts.join(", ")} from ${quote}${source}${quote};`;
+}
+
+function quoteFromSource(sourceNode) {
+  const raw = sourceNode && sourceNode.raw;
+  if (typeof raw === "string" && raw.length >= 1) {
+    const first = raw[0];
+    if (first === "'" || first === '"') return first;
+  }
+  return '"';
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow importing 'act' from 'react-dom/test-utils'; import it from 'react' instead",
+      url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
+    },
+    messages: {
+      noTestUtilsAct:
+        "'act' must be imported from 'react' in React 19, not 'react-dom/test-utils'.",
+    },
+    fixable: "code",
+    schema: [],
+    ruleId: "no-legacy-test-utils-act",
+    hasSuggestions: true,
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const testUtilsNamespaceVariables = new Set();
+
+    function trackNamespace(node) {
+      const [variable] = sourceCode.getDeclaredVariables(node);
+
+      if (variable) {
+        testUtilsNamespaceVariables.add(variable);
+      }
+    }
+
+    function isTrackedNamespaceIdentifier(node) {
+      const scope = sourceCode.getScope
+        ? sourceCode.getScope(node)
+        : context.getScope();
+      const variable = findVariable(scope, node.name);
+
+      return Boolean(variable && testUtilsNamespaceVariables.has(variable));
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== SOURCE) return;
+
+        const actSpecs = [];
+        const otherSpecs = [];
+
+        for (const spec of node.specifiers) {
+          if (
+            spec.type === "ImportSpecifier" &&
+            spec.imported &&
+            spec.imported.name === "act"
+          ) {
+            actSpecs.push(spec);
+          } else {
+            otherSpecs.push(spec);
+            if (
+              spec.type === "ImportDefaultSpecifier" ||
+              spec.type === "ImportNamespaceSpecifier"
+            ) {
+              trackNamespace(spec);
+            }
+          }
+        }
+
+        if (actSpecs.length === 0) return;
+
+        const quote = quoteFromSource(node.source);
+        const actText = actSpecs.map(specifierToText).join(", ");
+        const newReactImport = `import { ${actText} } from ${quote}react${quote};`;
+
+        const reportTarget = actSpecs.length === 1 ? actSpecs[0] : node;
+
+        context.report({
+          node: reportTarget,
+          messageId: "noTestUtilsAct",
+          fix(fixer) {
+            if (otherSpecs.length === 0) {
+              return fixer.replaceText(node, newReactImport);
+            }
+            const rebuilt = rebuildImport(otherSpecs, SOURCE, quote);
+            return fixer.replaceText(node, `${newReactImport}\n${rebuilt}`);
+          },
+        });
+      },
+
+      VariableDeclarator(node) {
+        if (
+          node.id.type === "Identifier" &&
+          isRequireTestUtils(node.init)
+        ) {
+          trackNamespace(node);
+          return;
+        }
+
+        if (
+          node.id.type === "ObjectPattern" &&
+          isRequireTestUtils(node.init)
+        ) {
+          for (const property of node.id.properties) {
+            if (property.type !== "Property" || property.computed) continue;
+
+            const keyName =
+              property.key.type === "Identifier"
+                ? property.key.name
+                : property.key.value;
+
+            if (keyName === "act") {
+              context.report({
+                node: property,
+                messageId: "noTestUtilsAct",
+              });
+            }
+          }
+        }
+      },
+
+      MemberExpression(node) {
+        if (
+          node.computed ||
+          node.property.type !== "Identifier" ||
+          node.property.name !== "act"
+        ) {
+          return;
+        }
+
+        if (
+          node.object.type === "Identifier" &&
+          isTrackedNamespaceIdentifier(node.object)
+        ) {
+          context.report({ node, messageId: "noTestUtilsAct" });
+          return;
+        }
+
+        if (isRequireTestUtils(node.object)) {
+          context.report({ node, messageId: "noTestUtilsAct" });
+        }
+      },
+    };
+  },
+};

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,6 +8,9 @@ const ruleNoPropTypes = require("../rules/no-prop-types");
 const ruleNoLegacyContext = require("../rules/no-legacy-context");
 const ruleNoStringRefs = require("../rules/no-string-refs");
 const ruleNoFactories = require("../rules/no-factories");
+const ruleNoLegacyReactDom = require("../rules/no-legacy-react-dom");
+const ruleNoLegacyReactDomServer = require("../rules/no-legacy-react-dom-server");
+const ruleNoLegacyTestUtilsAct = require("../rules/no-legacy-test-utils-act");
 
 // --- minimal describe/it harness (mirrors prior style, prints a tree) ---
 
@@ -72,13 +75,16 @@ describe("plugin api surface", () => {
     assert.ok(plugin.rules && typeof plugin.rules === "object", "plugin.rules exists");
   });
 
-  it("registers all five canonical rules", () => {
+  it("registers all eight canonical rules", () => {
     for (const name of [
       "no-default-props",
       "no-prop-types",
       "no-legacy-context",
       "no-string-refs",
       "no-factories",
+      "no-legacy-react-dom",
+      "no-legacy-react-dom-server",
+      "no-legacy-test-utils-act",
     ]) {
       assert.ok(plugin.rules[name], `rule ${name} is registered`);
     }
@@ -604,6 +610,246 @@ ruleTester.run("no-factories", ruleNoFactories, {
     {
       code: `const d = require('react').createFactory('div');`,
       errors: [{ messageId: "noCreateFactory" }],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 7. no-legacy-react-dom
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-legacy-react-dom", ruleNoLegacyReactDom, {
+  valid: [
+    // surviving react-dom APIs
+    `import ReactDOM from 'react-dom'; ReactDOM.flushSync(() => {});`,
+    `import { createPortal } from 'react-dom'; createPortal(child, container);`,
+    // different module
+    `const other = require('not-react-dom'); other.render(x, y);`,
+    // locally-defined render, no react-dom import
+    `const render = () => {}; render();`,
+    // the correct R19 replacement code
+    `import { createRoot } from 'react-dom/client'; createRoot(el).render(<App />);`,
+    `import { hydrateRoot } from 'react-dom/client'; hydrateRoot(el, <App />);`,
+    // react-dom/client is a different module
+    `import ReactDOMClient from 'react-dom/client'; ReactDOMClient.createRoot(el);`,
+    // shadowed local is not the imported namespace
+    `import ReactDOM from 'react-dom'; function useLocal(ReactDOM) { ReactDOM.render(<App />, root); }`,
+  ],
+  invalid: [
+    {
+      code: `import ReactDOM from 'react-dom'; ReactDOM.render(<App />, root);`,
+      errors: [{ messageId: "noRender" }],
+    },
+    {
+      code: `import { render } from 'react-dom'; render(<App />, root);`,
+      errors: [{ messageId: "noRender" }],
+    },
+    // removed import should fail even if unused
+    {
+      code: `import { render } from 'react-dom';`,
+      errors: [{ messageId: "noRender" }],
+    },
+    // aliased named import
+    {
+      code: `import { render as r } from 'react-dom'; r(<App />, root);`,
+      errors: [{ messageId: "noRender" }],
+    },
+    // removed member reference should fail even if not called
+    {
+      code: `import ReactDOM from 'react-dom'; const legacyRender = ReactDOM.render;`,
+      errors: [{ messageId: "noRender" }],
+    },
+    {
+      code: `import ReactDOM from 'react-dom'; ReactDOM.hydrate(<App />, root);`,
+      errors: [{ messageId: "noHydrate" }],
+    },
+    {
+      code: `import { hydrate } from 'react-dom'; hydrate(<App />, root);`,
+      errors: [{ messageId: "noHydrate" }],
+    },
+    {
+      code: `import ReactDOM from 'react-dom'; ReactDOM.unmountComponentAtNode(root);`,
+      errors: [{ messageId: "noUnmountComponentAtNode" }],
+    },
+    {
+      code: `const { unmountComponentAtNode } = require('react-dom'); unmountComponentAtNode(root);`,
+      errors: [{ messageId: "noUnmountComponentAtNode" }],
+    },
+    // destructured require should fail even if unused
+    {
+      code: `const { render } = require('react-dom');`,
+      errors: [{ messageId: "noRender" }],
+    },
+    {
+      code: `import ReactDOM from 'react-dom'; ReactDOM.findDOMNode(instance);`,
+      errors: [{ messageId: "noFindDOMNode" }],
+    },
+    {
+      code: `const { findDOMNode } = require('react-dom'); findDOMNode(instance);`,
+      errors: [{ messageId: "noFindDOMNode" }],
+    },
+    // renamed destructure from require
+    {
+      code: `const { render: r } = require('react-dom'); r(<App />, root);`,
+      errors: [{ messageId: "noRender" }],
+    },
+    // namespace import
+    {
+      code: `import * as RD from 'react-dom'; RD.findDOMNode(i);`,
+      errors: [{ messageId: "noFindDOMNode" }],
+    },
+    // inline require
+    {
+      code: `require('react-dom').render(<App />, root);`,
+      errors: [{ messageId: "noRender" }],
+    },
+    // CommonJS namespace var
+    {
+      code: `const ReactDOM = require('react-dom'); ReactDOM.hydrate(<App />, root);`,
+      errors: [{ messageId: "noHydrate" }],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 8. no-legacy-react-dom-server
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-legacy-react-dom-server", ruleNoLegacyReactDomServer, {
+  valid: [
+    // surviving exports
+    `import { renderToString } from 'react-dom/server'; renderToString(<App />);`,
+    `import { renderToStaticMarkup } from 'react-dom/server'; renderToStaticMarkup(<App />);`,
+    `import { renderToPipeableStream } from 'react-dom/server';`,
+    `import { renderToReadableStream } from 'react-dom/server';`,
+    `import Server from 'react-dom/server'; Server.renderToString(<App />);`,
+    // different module
+    `import { renderToNodeStream } from 'not-react-dom-server';`,
+    `const { renderToNodeStream } = require('something-else');`,
+    // shadowed local is not the imported namespace
+    `import Server from 'react-dom/server'; function useLocal(Server) { Server.renderToNodeStream(<App />); }`,
+  ],
+  invalid: [
+    {
+      code: `import { renderToNodeStream } from 'react-dom/server'; renderToNodeStream(<App />);`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+    {
+      code: `import { renderToStaticNodeStream } from 'react-dom/server';`,
+      errors: [{ messageId: "noRenderToStaticNodeStream" }],
+    },
+    // mixed import: allowlist proves surviving export is ignored
+    {
+      code: `import { renderToString, renderToNodeStream } from 'react-dom/server';`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+    // namespace access
+    {
+      code: `import Server from 'react-dom/server'; Server.renderToNodeStream(<App />);`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+    // removed member reference should fail even if not called
+    {
+      code: `import Server from 'react-dom/server'; const legacy = Server.renderToNodeStream;`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+    {
+      code: `import Server from 'react-dom/server'; Server.renderToStaticNodeStream(<App />);`,
+      errors: [{ messageId: "noRenderToStaticNodeStream" }],
+    },
+    // namespace * as
+    {
+      code: `import * as Server from 'react-dom/server'; Server.renderToNodeStream(<App />);`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+    // destructure from require
+    {
+      code: `const { renderToNodeStream } = require('react-dom/server');`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+    // CommonJS namespace var
+    {
+      code: `const Server = require('react-dom/server'); Server.renderToStaticNodeStream(<App />);`,
+      errors: [{ messageId: "noRenderToStaticNodeStream" }],
+    },
+    // inline require
+    {
+      code: `require('react-dom/server').renderToNodeStream(<App />);`,
+      errors: [{ messageId: "noRenderToNodeStream" }],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 9. no-legacy-test-utils-act
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-legacy-test-utils-act", ruleNoLegacyTestUtilsAct, {
+  valid: [
+    // correct R19 import
+    `import { act } from 'react'; act(() => {});`,
+    // unrelated test-utils export still legal
+    `import { Simulate } from 'react-dom/test-utils'; Simulate.click(node);`,
+    `const TestUtils = require('react-dom/test-utils'); TestUtils.Simulate.click(node);`,
+    // different module
+    `import TestUtils from 'other/test-utils'; TestUtils.act(() => {});`,
+    // local identifier coincidentally named act, no test-utils binding
+    `const act = (fn) => fn(); act(() => {});`,
+    // shadowed local is not the imported namespace
+    `import TestUtils from 'react-dom/test-utils'; function useLocal(TestUtils) { TestUtils.act(() => {}); }`,
+  ],
+  invalid: [
+    // simple named import — fixable
+    {
+      code: `import { act } from 'react-dom/test-utils'; act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act } from 'react'; act(() => {});`,
+    },
+    // aliased named import — alias preserved
+    {
+      code: `import { act as a } from 'react-dom/test-utils'; a(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act as a } from 'react'; a(() => {});`,
+    },
+    // mixed — split into two imports
+    {
+      code: `import { act, Simulate } from 'react-dom/test-utils';`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act } from 'react';\nimport { Simulate } from 'react-dom/test-utils';`,
+    },
+    // default + named — default stays, act moves
+    {
+      code: `import TestUtils, { act } from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act } from 'react';\nimport TestUtils from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
+    },
+    // namespace + act via member access — reported, not fixed
+    {
+      code: `import TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
+      errors: [
+        { messageId: "noTestUtilsAct" },
+      ],
+    },
+    {
+      code: `import * as TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
+      errors: [
+        { messageId: "noTestUtilsAct" },
+      ],
+    },
+    // CommonJS destructure — reported, not fixed
+    {
+      code: `const { act } = require('react-dom/test-utils'); act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+    },
+    // CommonJS namespace var + member access
+    {
+      code: `const TestUtils = require('react-dom/test-utils'); TestUtils.act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+    },
+    // inline require
+    {
+      code: `require('react-dom/test-utils').act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
     },
   ],
 });


### PR DESCRIPTION
## What changed

This adds three React 19 upgrade rules to the plugin:

- `no-legacy-react-dom`
- `no-legacy-react-dom-server`
- `no-legacy-test-utils-act`

It also registers the rules in the plugin export, documents them in the README, and expands the test suite to cover the new rule behavior.

## Why

React 19 removes several legacy `react-dom` and `react-dom/server` APIs, and requires `act` to come from `react` instead of `react-dom/test-utils`.

The initial rule/test work covered the common call-site cases, but it missed some invalid import/reference patterns and allowed false positives when imported namespaces were shadowed by local bindings.

## Impact

Users upgrading to React 19 will now get lint coverage for:

- removed `react-dom` APIs
- removed `react-dom/server` streaming APIs
- legacy `react-dom/test-utils` `act` usage

The rules also avoid reporting shadowed local identifiers that are unrelated to the tracked imports.

## Root cause

The original implementations relied on name tracking without scope resolution, and `no-legacy-react-dom` only reported removed APIs when they were called.

## Validation

- `npm test`
- 144 passed, 0 failed
