### PR TITLE
Add supply-chain hardening for CI and npm publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,15 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: npm

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
   },
   "homepage": "https://github.com/brettfarrow/eslint-plugin-react-19-upgrade",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "rules/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "test": "node tests/tests.js"
   },


### PR DESCRIPTION
## Summary

Follow-up from a full security audit of the repo (verdict: **no vulnerabilities found, risk LOW**). These changes are preventative supply-chain hardening, not fixes for any actual issue:

- **CI token least privilege**: add a top-level `permissions: contents: read` block to `ci.yml` so the workflow's `GITHUB_TOKEN` can't write to the repo regardless of org/repo defaults.
- **SHA-pin GitHub Actions**: pin `actions/checkout` and `actions/setup-node` to full commit SHAs (with `# v6` comments) so a moved or compromised tag can't inject code into CI.
- **npm publish allowlist**: add a `files` field to `package.json` so the published tarball contains only `index.js`, `rules/`, `README.md`, and `LICENSE` — tests, CI config, and lockfile are no longer shipped.
- **Dependabot**: weekly update PRs for npm devDependencies and GitHub Actions (also keeps the pinned SHAs fresh).

## Test plan

- [x] `npm test` — 144 passed, 0 failed
- [x] `npm pack --dry-run` — tarball contains exactly the 12 allowlisted files (7.7 kB)
- [x] CI passes on this PR with the restricted permissions and pinned SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)