### PR TITLE
Complete React 19 breaking-change coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Then configure the rules you want to use under the rules section.
     "react-19-upgrade/no-factories": "error",
     "react-19-upgrade/no-legacy-react-dom": "error",
     "react-19-upgrade/no-legacy-react-dom-server": "error",
-    "react-19-upgrade/no-legacy-test-utils-act": "error"
+    "react-19-upgrade/no-legacy-test-utils-act": "error",
+    "react-19-upgrade/no-legacy-react-is": "error",
+    "react-19-upgrade/no-shallow-renderer": "error",
+    "react-19-upgrade/no-implicit-ref-callback-return": "error"
   }
 }
 ```
@@ -55,9 +58,12 @@ Then configure the rules you want to use under the rules section.
 - `no-legacy-context`: Disallow the use of legacy context APIs in React class components.
 - `no-string-refs`: Disallow the use of string refs in React components.
 - `no-factories`: Disallow module pattern factories and React.createFactory.
-- `no-legacy-react-dom`: Disallow removed `react-dom` APIs (`render`, `hydrate`, `unmountComponentAtNode`, `findDOMNode`). Use `createRoot`/`hydrateRoot` from `react-dom/client`, or refs, instead.
+- `no-legacy-react-dom`: Disallow removed `react-dom` APIs (`render`, `hydrate`, `unmountComponentAtNode`, `findDOMNode`, plus the removed `unstable_flushControlled`, `unstable_createEventHandle`, `renderSubtreeIntoContainer`/`unstable_renderSubtreeIntoContainer`, and `unstable_runWithPriority`). Use `createRoot`/`hydrateRoot` from `react-dom/client`, or refs, instead.
 - `no-legacy-react-dom-server`: Disallow `renderToNodeStream` and `renderToStaticNodeStream` from `react-dom/server`. Use `renderToPipeableStream` instead (note: different signature).
-- `no-legacy-test-utils-act`: Import `act` from `react`, not `react-dom/test-utils`. Fixable by ESLint.
+- `no-legacy-test-utils-act`: Disallow importing from `react-dom/test-utils`, which is removed in React 19. `act` imports are rewritten to import from `react` (Fixable by ESLint); the other utilities (`Simulate`, `renderIntoDocument`, etc.) are reported with a pointer to `@testing-library/react`.
+- `no-legacy-react-is`: Disallow `isConcurrentMode` and `isAsyncMode` from `react-is`, removed in React 19 without a replacement.
+- `no-shallow-renderer`: Disallow importing `react-test-renderer/shallow`, removed in React 19. Rewritten to `react-shallow-renderer` (install it first). Fixable by ESLint.
+- `no-implicit-ref-callback-return`: Disallow implicit returns in JSX ref callbacks (`ref={el => (this.el = el)}`) — React 19 treats the returned value as a cleanup function. The body is wrapped in braces (Fixable by ESLint). Only arrow expression bodies are flagged, matching the official `react/19` codemod; explicit `return` statements and function-expression refs are left alone.
 
 ### `element.ref` access
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then configure the rules you want to use under the rules section.
     "react-19-upgrade/no-factories": "error",
     "react-19-upgrade/no-legacy-react-dom": "error",
     "react-19-upgrade/no-legacy-react-dom-server": "error",
-    "react-19-upgrade/no-legacy-test-utils-act": "error",
+    "react-19-upgrade/no-legacy-test-utils": "error",
     "react-19-upgrade/no-legacy-react-is": "error",
     "react-19-upgrade/no-shallow-renderer": "error",
     "react-19-upgrade/no-implicit-ref-callback-return": "error"
@@ -60,7 +60,8 @@ Then configure the rules you want to use under the rules section.
 - `no-factories`: Disallow module pattern factories and React.createFactory.
 - `no-legacy-react-dom`: Disallow removed `react-dom` APIs (`render`, `hydrate`, `unmountComponentAtNode`, `findDOMNode`, plus the removed `unstable_flushControlled`, `unstable_createEventHandle`, `renderSubtreeIntoContainer`/`unstable_renderSubtreeIntoContainer`, and `unstable_runWithPriority`). Use `createRoot`/`hydrateRoot` from `react-dom/client`, or refs, instead.
 - `no-legacy-react-dom-server`: Disallow `renderToNodeStream` and `renderToStaticNodeStream` from `react-dom/server`. Use `renderToPipeableStream` instead (note: different signature).
-- `no-legacy-test-utils-act`: Disallow importing from `react-dom/test-utils`, which is removed in React 19. `act` imports are rewritten to import from `react` (Fixable by ESLint); the other utilities (`Simulate`, `renderIntoDocument`, etc.) are reported with a pointer to `@testing-library/react`.
+- `no-legacy-test-utils`: Disallow importing from `react-dom/test-utils`, which is removed entirely in React 19. `act` imports are rewritten to import from `react` (Fixable by ESLint); the other utilities (`Simulate`, `renderIntoDocument`, etc.) are reported with a pointer to `@testing-library/react`. Supersedes `no-legacy-test-utils-act` — enable one or the other, not both.
+- `no-legacy-test-utils-act`: Import `act` from `react`, not `react-dom/test-utils`. Fixable by ESLint. Narrower than `no-legacy-test-utils` (only flags `act`); kept for backwards compatibility.
 - `no-legacy-react-is`: Disallow `isConcurrentMode` and `isAsyncMode` from `react-is`, removed in React 19 without a replacement.
 - `no-shallow-renderer`: Disallow importing `react-test-renderer/shallow`, removed in React 19. Rewritten to `react-shallow-renderer` (install it first). Fixable by ESLint.
 - `no-implicit-ref-callback-return`: Disallow implicit returns in JSX ref callbacks (`ref={el => (this.el = el)}`) — React 19 treats the returned value as a cleanup function. The body is wrapped in braces (Fixable by ESLint). Only arrow expression bodies are flagged, matching the official `react/19` codemod; explicit `return` statements and function-expression refs are left alone.

--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ module.exports = {
     "no-legacy-react-dom": require("./rules/no-legacy-react-dom"),
     "no-legacy-react-dom-server": require("./rules/no-legacy-react-dom-server"),
     "no-legacy-test-utils-act": require("./rules/no-legacy-test-utils-act"),
+    "no-legacy-react-is": require("./rules/no-legacy-react-is"),
+    "no-shallow-renderer": require("./rules/no-shallow-renderer"),
+    "no-implicit-ref-callback-return": require("./rules/no-implicit-ref-callback-return"),
     // equivalent but without the extra dash
     "no-defaultprops": require("./rules/no-default-props"),
     "no-proptypes": require("./rules/no-prop-types"),

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "no-legacy-react-dom": require("./rules/no-legacy-react-dom"),
     "no-legacy-react-dom-server": require("./rules/no-legacy-react-dom-server"),
     "no-legacy-test-utils-act": require("./rules/no-legacy-test-utils-act"),
+    "no-legacy-test-utils": require("./rules/no-legacy-test-utils"),
     "no-legacy-react-is": require("./rules/no-legacy-react-is"),
     "no-shallow-renderer": require("./rules/no-shallow-renderer"),
     "no-implicit-ref-callback-return": require("./rules/no-implicit-ref-callback-return"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-react-19-upgrade",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-react-19-upgrade",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-react-19-upgrade",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "An ESLint plugin to identify and fix breaking changes when upgrading React 18 to React 19",
   "main": "index.js",
   "author": "Brett Farrow",

--- a/rules/no-implicit-ref-callback-return.js
+++ b/rules/no-implicit-ref-callback-return.js
@@ -1,0 +1,94 @@
+// rules/no-implicit-ref-callback-return.js
+
+function isAllowedBody(body) {
+  if (body.type === "Identifier" && body.name === "undefined") {
+    return true;
+  }
+
+  if (body.type === "UnaryExpression" && body.operator === "void") {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow implicit returns in JSX ref callbacks; React 19 treats the returned value as a cleanup function",
+      url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#cleanup-functions-for-refs",
+    },
+    messages: {
+      noImplicitRefCallbackReturn:
+        "Ref callbacks must not implicitly return a value; React 19 treats it as a cleanup function. Wrap the body in braces.",
+    },
+    fixable: "code",
+    schema: [],
+    ruleId: "no-implicit-ref-callback-return",
+    hasSuggestions: true,
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    return {
+      "JSXAttribute[name.name='ref']"(node) {
+        const value = node.value;
+
+        if (
+          !value ||
+          value.type !== "JSXExpressionContainer" ||
+          !value.expression ||
+          value.expression.type !== "ArrowFunctionExpression"
+        ) {
+          return;
+        }
+
+        const arrowFn = value.expression;
+
+        if (!arrowFn.expression) {
+          return;
+        }
+
+        const body = arrowFn.body;
+
+        if (isAllowedBody(body)) {
+          return;
+        }
+
+        // Comments between the arrow token and the end of the function (but
+        // outside the body itself) would be swallowed by the rewrite; report
+        // without a fix in that case.
+        const hasAdjacentComments = sourceCode
+          .getCommentsInside(arrowFn)
+          .some(
+            (comment) =>
+              comment.range[0] < body.range[0] ||
+              comment.range[1] > body.range[1],
+          );
+
+        context.report({
+          node: body,
+          messageId: "noImplicitRefCallbackReturn",
+          fix: hasAdjacentComments
+            ? undefined
+            : (fixer) => {
+                const arrowToken = sourceCode.getTokenBefore(
+                  body,
+                  (token) =>
+                    token.type === "Punctuator" && token.value === "=>",
+                );
+
+                // The replaced range ends at the arrow function's end, which
+                // includes any parentheses wrapping the expression body.
+                return fixer.replaceTextRange(
+                  [arrowToken.range[1], arrowFn.range[1]],
+                  ` { ${sourceCode.getText(body)}; }`,
+                );
+              },
+        });
+      },
+    };
+  },
+};

--- a/rules/no-legacy-react-is.js
+++ b/rules/no-legacy-react-is.js
@@ -1,17 +1,10 @@
-// rules/no-legacy-react-dom.js
+// rules/no-legacy-react-is.js
 
-const SOURCE = "react-dom";
+const SOURCE = "react-is";
 
 const REMOVED_APIS = {
-  render: "noRender",
-  hydrate: "noHydrate",
-  unmountComponentAtNode: "noUnmountComponentAtNode",
-  findDOMNode: "noFindDOMNode",
-  unstable_flushControlled: "noUnstableFlushControlled",
-  unstable_createEventHandle: "noUnstableCreateEventHandle",
-  unstable_renderSubtreeIntoContainer: "noUnstableRenderSubtreeIntoContainer",
-  renderSubtreeIntoContainer: "noRenderSubtreeIntoContainer",
-  unstable_runWithPriority: "noUnstableRunWithPriority",
+  isConcurrentMode: "noIsConcurrentMode",
+  isAsyncMode: "noIsAsyncMode",
 };
 
 function findVariable(scope, name) {
@@ -30,7 +23,7 @@ function findVariable(scope, name) {
   return null;
 }
 
-function isRequireReactDom(node) {
+function isRequireReactIs(node) {
   return (
     node &&
     node.type === "CallExpression" &&
@@ -47,31 +40,17 @@ module.exports = {
     type: "problem",
     docs: {
       description:
-        "Disallow react-dom APIs removed in React 19 (render, hydrate, unmountComponentAtNode, findDOMNode, and the removed unstable_* APIs)",
+        "Disallow 'isConcurrentMode' and 'isAsyncMode' from 'react-is' (removed in React 19)",
       url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
     },
     messages: {
-      noRender:
-        "'ReactDOM.render' is removed in React 19. Import 'createRoot' from 'react-dom/client' and call 'createRoot(container).render(element)' instead.",
-      noHydrate:
-        "'ReactDOM.hydrate' is removed in React 19. Import 'hydrateRoot' from 'react-dom/client' and call 'hydrateRoot(container, element)' instead.",
-      noUnmountComponentAtNode:
-        "'ReactDOM.unmountComponentAtNode' is removed in React 19. Hold on to the root returned by 'createRoot' and call 'root.unmount()' instead.",
-      noFindDOMNode:
-        "'ReactDOM.findDOMNode' is removed in React 19. Attach a ref to the DOM node you need instead.",
-      noUnstableFlushControlled:
-        "'ReactDOM.unstable_flushControlled' is removed in React 19 without a replacement.",
-      noUnstableCreateEventHandle:
-        "'ReactDOM.unstable_createEventHandle' is removed in React 19 without a replacement.",
-      noUnstableRenderSubtreeIntoContainer:
-        "'ReactDOM.unstable_renderSubtreeIntoContainer' is removed in React 19 without a replacement. Consider 'createPortal' from 'react-dom'.",
-      noRenderSubtreeIntoContainer:
-        "'ReactDOM.renderSubtreeIntoContainer' is removed in React 19 without a replacement. Consider 'createPortal' from 'react-dom'.",
-      noUnstableRunWithPriority:
-        "'ReactDOM.unstable_runWithPriority' is removed in React 19 without a replacement.",
+      noIsConcurrentMode:
+        "'isConcurrentMode' from 'react-is' is removed in React 19 without a replacement.",
+      noIsAsyncMode:
+        "'isAsyncMode' from 'react-is' is removed in React 19 without a replacement.",
     },
     schema: [],
-    ruleId: "no-legacy-react-dom",
+    ruleId: "no-legacy-react-is",
     hasSuggestions: true,
   },
   create(context) {
@@ -123,7 +102,7 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        if (!isRequireReactDom(node.init)) return;
+        if (!isRequireReactIs(node.init)) return;
 
         if (node.id.type === "Identifier") {
           trackNamespace(node);
@@ -161,7 +140,7 @@ module.exports = {
           return;
         }
 
-        if (isRequireReactDom(node.object)) {
+        if (isRequireReactIs(node.object)) {
           reportApi(node, apiName);
         }
       },

--- a/rules/no-legacy-test-utils-act.js
+++ b/rules/no-legacy-test-utils-act.js
@@ -2,22 +2,6 @@
 
 const SOURCE = "react-dom/test-utils";
 
-function findVariable(scope, name) {
-  let currentScope = scope;
-
-  while (currentScope) {
-    const variable = currentScope.variables.find((item) => item.name === name);
-
-    if (variable) {
-      return variable;
-    }
-
-    currentScope = currentScope.upper;
-  }
-
-  return null;
-}
-
 function isRequireTestUtils(node) {
   return (
     node &&
@@ -30,12 +14,17 @@ function isRequireTestUtils(node) {
   );
 }
 
+function importedName(spec) {
+  if (!spec.imported) return null;
+  return spec.imported.name ?? spec.imported.value;
+}
+
 function specifierToText(spec) {
   if (spec.type !== "ImportSpecifier") return null;
-  if (spec.local.name === spec.imported.name) {
-    return spec.imported.name;
+  if (spec.local.name === importedName(spec)) {
+    return importedName(spec);
   }
-  return `${spec.imported.name} as ${spec.local.name}`;
+  return `${importedName(spec)} as ${spec.local.name}`;
 }
 
 function rebuildImport(specs, source, quote) {
@@ -67,12 +56,16 @@ module.exports = {
     type: "problem",
     docs: {
       description:
-        "Disallow importing 'act' from 'react-dom/test-utils'; import it from 'react' instead",
+        "Disallow importing from 'react-dom/test-utils' (removed in React 19); import 'act' from 'react' and use '@testing-library/react' for other utilities",
       url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
     },
     messages: {
       noTestUtilsAct:
         "'act' must be imported from 'react' in React 19, not 'react-dom/test-utils'.",
+      noTestUtilsRemoved:
+        "'{{name}}' from 'react-dom/test-utils' is removed in React 19. Use '@testing-library/react' or another modern testing utility instead.",
+      noTestUtilsModule:
+        "'react-dom/test-utils' is removed in React 19. Import 'act' from 'react'; use '@testing-library/react' for other utilities.",
     },
     fixable: "code",
     schema: [],
@@ -80,47 +73,31 @@ module.exports = {
     hasSuggestions: true,
   },
   create(context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
-    const testUtilsNamespaceVariables = new Set();
-
-    function trackNamespace(node) {
-      const [variable] = sourceCode.getDeclaredVariables(node);
-
-      if (variable) {
-        testUtilsNamespaceVariables.add(variable);
-      }
-    }
-
-    function isTrackedNamespaceIdentifier(node) {
-      const scope = sourceCode.getScope
-        ? sourceCode.getScope(node)
-        : context.getScope();
-      const variable = findVariable(scope, node.name);
-
-      return Boolean(variable && testUtilsNamespaceVariables.has(variable));
-    }
-
     return {
       ImportDeclaration(node) {
         if (node.source.value !== SOURCE) return;
+
+        if (node.specifiers.length === 0) {
+          context.report({ node, messageId: "noTestUtilsModule" });
+          return;
+        }
 
         const actSpecs = [];
         const otherSpecs = [];
 
         for (const spec of node.specifiers) {
-          if (
-            spec.type === "ImportSpecifier" &&
-            spec.imported &&
-            spec.imported.name === "act"
-          ) {
+          if (spec.type === "ImportSpecifier" && importedName(spec) === "act") {
             actSpecs.push(spec);
           } else {
             otherSpecs.push(spec);
-            if (
-              spec.type === "ImportDefaultSpecifier" ||
-              spec.type === "ImportNamespaceSpecifier"
-            ) {
-              trackNamespace(spec);
+            if (spec.type === "ImportSpecifier") {
+              context.report({
+                node: spec,
+                messageId: "noTestUtilsRemoved",
+                data: { name: importedName(spec) },
+              });
+            } else {
+              context.report({ node: spec, messageId: "noTestUtilsModule" });
             }
           }
         }
@@ -147,18 +124,14 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        if (
-          node.id.type === "Identifier" &&
-          isRequireTestUtils(node.init)
-        ) {
-          trackNamespace(node);
+        if (!isRequireTestUtils(node.init)) return;
+
+        if (node.id.type === "Identifier") {
+          context.report({ node, messageId: "noTestUtilsModule" });
           return;
         }
 
-        if (
-          node.id.type === "ObjectPattern" &&
-          isRequireTestUtils(node.init)
-        ) {
+        if (node.id.type === "ObjectPattern") {
           for (const property of node.id.properties) {
             if (property.type !== "Property" || property.computed) continue;
 
@@ -172,30 +145,32 @@ module.exports = {
                 node: property,
                 messageId: "noTestUtilsAct",
               });
+            } else {
+              context.report({
+                node: property,
+                messageId: "noTestUtilsRemoved",
+                data: { name: keyName },
+              });
             }
           }
         }
       },
 
       MemberExpression(node) {
-        if (
-          node.computed ||
-          node.property.type !== "Identifier" ||
-          node.property.name !== "act"
-        ) {
+        if (node.computed || node.property.type !== "Identifier") {
           return;
         }
 
-        if (
-          node.object.type === "Identifier" &&
-          isTrackedNamespaceIdentifier(node.object)
-        ) {
-          context.report({ node, messageId: "noTestUtilsAct" });
-          return;
-        }
+        if (!isRequireTestUtils(node.object)) return;
 
-        if (isRequireTestUtils(node.object)) {
+        if (node.property.name === "act") {
           context.report({ node, messageId: "noTestUtilsAct" });
+        } else {
+          context.report({
+            node,
+            messageId: "noTestUtilsRemoved",
+            data: { name: node.property.name },
+          });
         }
       },
     };

--- a/rules/no-legacy-test-utils.js
+++ b/rules/no-legacy-test-utils.js
@@ -1,22 +1,6 @@
-// rules/no-legacy-test-utils-act.js
+// rules/no-legacy-test-utils.js
 
 const SOURCE = "react-dom/test-utils";
-
-function findVariable(scope, name) {
-  let currentScope = scope;
-
-  while (currentScope) {
-    const variable = currentScope.variables.find((item) => item.name === name);
-
-    if (variable) {
-      return variable;
-    }
-
-    currentScope = currentScope.upper;
-  }
-
-  return null;
-}
 
 function isRequireTestUtils(node) {
   return (
@@ -30,12 +14,17 @@ function isRequireTestUtils(node) {
   );
 }
 
+function importedName(spec) {
+  if (!spec.imported) return null;
+  return spec.imported.name ?? spec.imported.value;
+}
+
 function specifierToText(spec) {
   if (spec.type !== "ImportSpecifier") return null;
-  if (spec.local.name === spec.imported.name) {
-    return spec.imported.name;
+  if (spec.local.name === importedName(spec)) {
+    return importedName(spec);
   }
-  return `${spec.imported.name} as ${spec.local.name}`;
+  return `${importedName(spec)} as ${spec.local.name}`;
 }
 
 function rebuildImport(specs, source, quote) {
@@ -67,60 +56,48 @@ module.exports = {
     type: "problem",
     docs: {
       description:
-        "Disallow importing 'act' from 'react-dom/test-utils'; import it from 'react' instead",
+        "Disallow importing from 'react-dom/test-utils' (removed in React 19); import 'act' from 'react' and use '@testing-library/react' for other utilities",
       url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
     },
     messages: {
       noTestUtilsAct:
         "'act' must be imported from 'react' in React 19, not 'react-dom/test-utils'.",
+      noTestUtilsRemoved:
+        "'{{name}}' from 'react-dom/test-utils' is removed in React 19. Use '@testing-library/react' or another modern testing utility instead.",
+      noTestUtilsModule:
+        "'react-dom/test-utils' is removed in React 19. Import 'act' from 'react'; use '@testing-library/react' for other utilities.",
     },
     fixable: "code",
     schema: [],
-    ruleId: "no-legacy-test-utils-act",
+    ruleId: "no-legacy-test-utils",
     hasSuggestions: true,
   },
   create(context) {
-    const sourceCode = context.sourceCode ?? context.getSourceCode();
-    const testUtilsNamespaceVariables = new Set();
-
-    function trackNamespace(node) {
-      const [variable] = sourceCode.getDeclaredVariables(node);
-
-      if (variable) {
-        testUtilsNamespaceVariables.add(variable);
-      }
-    }
-
-    function isTrackedNamespaceIdentifier(node) {
-      const scope = sourceCode.getScope
-        ? sourceCode.getScope(node)
-        : context.getScope();
-      const variable = findVariable(scope, node.name);
-
-      return Boolean(variable && testUtilsNamespaceVariables.has(variable));
-    }
-
     return {
       ImportDeclaration(node) {
         if (node.source.value !== SOURCE) return;
+
+        if (node.specifiers.length === 0) {
+          context.report({ node, messageId: "noTestUtilsModule" });
+          return;
+        }
 
         const actSpecs = [];
         const otherSpecs = [];
 
         for (const spec of node.specifiers) {
-          if (
-            spec.type === "ImportSpecifier" &&
-            spec.imported &&
-            spec.imported.name === "act"
-          ) {
+          if (spec.type === "ImportSpecifier" && importedName(spec) === "act") {
             actSpecs.push(spec);
           } else {
             otherSpecs.push(spec);
-            if (
-              spec.type === "ImportDefaultSpecifier" ||
-              spec.type === "ImportNamespaceSpecifier"
-            ) {
-              trackNamespace(spec);
+            if (spec.type === "ImportSpecifier") {
+              context.report({
+                node: spec,
+                messageId: "noTestUtilsRemoved",
+                data: { name: importedName(spec) },
+              });
+            } else {
+              context.report({ node: spec, messageId: "noTestUtilsModule" });
             }
           }
         }
@@ -147,18 +124,14 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
-        if (
-          node.id.type === "Identifier" &&
-          isRequireTestUtils(node.init)
-        ) {
-          trackNamespace(node);
+        if (!isRequireTestUtils(node.init)) return;
+
+        if (node.id.type === "Identifier") {
+          context.report({ node, messageId: "noTestUtilsModule" });
           return;
         }
 
-        if (
-          node.id.type === "ObjectPattern" &&
-          isRequireTestUtils(node.init)
-        ) {
+        if (node.id.type === "ObjectPattern") {
           for (const property of node.id.properties) {
             if (property.type !== "Property" || property.computed) continue;
 
@@ -172,30 +145,32 @@ module.exports = {
                 node: property,
                 messageId: "noTestUtilsAct",
               });
+            } else {
+              context.report({
+                node: property,
+                messageId: "noTestUtilsRemoved",
+                data: { name: keyName },
+              });
             }
           }
         }
       },
 
       MemberExpression(node) {
-        if (
-          node.computed ||
-          node.property.type !== "Identifier" ||
-          node.property.name !== "act"
-        ) {
+        if (node.computed || node.property.type !== "Identifier") {
           return;
         }
 
-        if (
-          node.object.type === "Identifier" &&
-          isTrackedNamespaceIdentifier(node.object)
-        ) {
-          context.report({ node, messageId: "noTestUtilsAct" });
-          return;
-        }
+        if (!isRequireTestUtils(node.object)) return;
 
-        if (isRequireTestUtils(node.object)) {
+        if (node.property.name === "act") {
           context.report({ node, messageId: "noTestUtilsAct" });
+        } else {
+          context.report({
+            node,
+            messageId: "noTestUtilsRemoved",
+            data: { name: node.property.name },
+          });
         }
       },
     };

--- a/rules/no-shallow-renderer.js
+++ b/rules/no-shallow-renderer.js
@@ -1,0 +1,80 @@
+// rules/no-shallow-renderer.js
+
+const SOURCE = "react-test-renderer/shallow";
+const REPLACEMENT = "react-shallow-renderer";
+
+function isRequireShallowRenderer(node) {
+  return (
+    node &&
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === "require" &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === "Literal" &&
+    node.arguments[0].value === SOURCE
+  );
+}
+
+function quoteFromSource(sourceNode) {
+  const raw = sourceNode && sourceNode.raw;
+  if (typeof raw === "string" && raw.length >= 1) {
+    const first = raw[0];
+    if (first === "'" || first === '"') return first;
+  }
+  return '"';
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow importing 'react-test-renderer/shallow' (removed in React 19); install and import 'react-shallow-renderer' directly",
+      url: "https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations",
+    },
+    messages: {
+      noShallowRenderer:
+        "'react-test-renderer/shallow' is removed in React 19. Install 'react-shallow-renderer' and import it directly.",
+    },
+    fixable: "code",
+    schema: [],
+    ruleId: "no-shallow-renderer",
+    hasSuggestions: true,
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== SOURCE) return;
+
+        const quote = quoteFromSource(node.source);
+        context.report({
+          node,
+          messageId: "noShallowRenderer",
+          fix(fixer) {
+            return fixer.replaceText(
+              node.source,
+              `${quote}${REPLACEMENT}${quote}`,
+            );
+          },
+        });
+      },
+
+      CallExpression(node) {
+        if (!isRequireShallowRenderer(node)) return;
+
+        const sourceNode = node.arguments[0];
+        const quote = quoteFromSource(sourceNode);
+        context.report({
+          node,
+          messageId: "noShallowRenderer",
+          fix(fixer) {
+            return fixer.replaceText(
+              sourceNode,
+              `${quote}${REPLACEMENT}${quote}`,
+            );
+          },
+        });
+      },
+    };
+  },
+};

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -11,6 +11,9 @@ const ruleNoFactories = require("../rules/no-factories");
 const ruleNoLegacyReactDom = require("../rules/no-legacy-react-dom");
 const ruleNoLegacyReactDomServer = require("../rules/no-legacy-react-dom-server");
 const ruleNoLegacyTestUtilsAct = require("../rules/no-legacy-test-utils-act");
+const ruleNoLegacyReactIs = require("../rules/no-legacy-react-is");
+const ruleNoShallowRenderer = require("../rules/no-shallow-renderer");
+const ruleNoImplicitRefCallbackReturn = require("../rules/no-implicit-ref-callback-return");
 
 // --- minimal describe/it harness (mirrors prior style, prints a tree) ---
 
@@ -75,7 +78,7 @@ describe("plugin api surface", () => {
     assert.ok(plugin.rules && typeof plugin.rules === "object", "plugin.rules exists");
   });
 
-  it("registers all eight canonical rules", () => {
+  it("registers all eleven canonical rules", () => {
     for (const name of [
       "no-default-props",
       "no-prop-types",
@@ -85,6 +88,9 @@ describe("plugin api surface", () => {
       "no-legacy-react-dom",
       "no-legacy-react-dom-server",
       "no-legacy-test-utils-act",
+      "no-legacy-react-is",
+      "no-shallow-renderer",
+      "no-implicit-ref-callback-return",
     ]) {
       assert.ok(plugin.rules[name], `rule ${name} is registered`);
     }
@@ -708,6 +714,36 @@ ruleTester.run("no-legacy-react-dom", ruleNoLegacyReactDom, {
       code: `const ReactDOM = require('react-dom'); ReactDOM.hydrate(<App />, root);`,
       errors: [{ messageId: "noHydrate" }],
     },
+    // removed unstable_* APIs
+    {
+      code: `import ReactDOM from 'react-dom'; ReactDOM.unstable_flushControlled(fn);`,
+      errors: [{ messageId: "noUnstableFlushControlled" }],
+    },
+    // removed unstable import should fail even if unused
+    {
+      code: `import { unstable_createEventHandle } from 'react-dom';`,
+      errors: [{ messageId: "noUnstableCreateEventHandle" }],
+    },
+    // aliased named import
+    {
+      code: `import { unstable_flushControlled as fc } from 'react-dom'; fc(fn);`,
+      errors: [{ messageId: "noUnstableFlushControlled" }],
+    },
+    // destructure from require
+    {
+      code: `const { unstable_renderSubtreeIntoContainer } = require('react-dom');`,
+      errors: [{ messageId: "noUnstableRenderSubtreeIntoContainer" }],
+    },
+    // namespace import
+    {
+      code: `import * as RD from 'react-dom'; RD.renderSubtreeIntoContainer(parent, el, container);`,
+      errors: [{ messageId: "noRenderSubtreeIntoContainer" }],
+    },
+    // inline require
+    {
+      code: `require('react-dom').unstable_runWithPriority(priority, fn);`,
+      errors: [{ messageId: "noUnstableRunWithPriority" }],
+    },
   ],
 });
 
@@ -788,15 +824,13 @@ ruleTester.run("no-legacy-test-utils-act", ruleNoLegacyTestUtilsAct, {
   valid: [
     // correct R19 import
     `import { act } from 'react'; act(() => {});`,
-    // unrelated test-utils export still legal
-    `import { Simulate } from 'react-dom/test-utils'; Simulate.click(node);`,
-    `const TestUtils = require('react-dom/test-utils'); TestUtils.Simulate.click(node);`,
+    // the modern replacement for the removed utilities
+    `import { render } from '@testing-library/react'; render(<App />);`,
     // different module
     `import TestUtils from 'other/test-utils'; TestUtils.act(() => {});`,
+    `const TestUtils = require('other/test-utils'); TestUtils.Simulate.click(node);`,
     // local identifier coincidentally named act, no test-utils binding
     `const act = (fn) => fn(); act(() => {});`,
-    // shadowed local is not the imported namespace
-    `import TestUtils from 'react-dom/test-utils'; function useLocal(TestUtils) { TestUtils.act(() => {}); }`,
   ],
   invalid: [
     // simple named import — fixable
@@ -811,48 +845,297 @@ ruleTester.run("no-legacy-test-utils-act", ruleNoLegacyTestUtilsAct, {
       errors: [{ messageId: "noTestUtilsAct" }],
       output: `import { act as a } from 'react'; a(() => {});`,
     },
-    // mixed — split into two imports
+    // mixed — act split out; the removed utility flagged and left for a later pass
     {
       code: `import { act, Simulate } from 'react-dom/test-utils';`,
-      errors: [{ messageId: "noTestUtilsAct" }],
-      output: `import { act } from 'react';\nimport { Simulate } from 'react-dom/test-utils';`,
-    },
-    // default + named — default stays, act moves
-    {
-      code: `import TestUtils, { act } from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
-      errors: [{ messageId: "noTestUtilsAct" }],
-      output: `import { act } from 'react';\nimport TestUtils from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
-    },
-    // namespace + act via member access — reported, not fixed
-    {
-      code: `import TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
       errors: [
         { messageId: "noTestUtilsAct" },
+        { messageId: "noTestUtilsRemoved", data: { name: "Simulate" } },
       ],
+      output: `import { act } from 'react';\nimport { Simulate } from 'react-dom/test-utils';`,
+    },
+    // default + named — default flagged as removed module, act moves
+    {
+      code: `import TestUtils, { act } from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
+      errors: [
+        { messageId: "noTestUtilsModule" },
+        { messageId: "noTestUtilsAct" },
+      ],
+      output: `import { act } from 'react';\nimport TestUtils from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
+    },
+    // removed utility as named import
+    {
+      code: `import { Simulate } from 'react-dom/test-utils'; Simulate.click(node);`,
+      errors: [{ messageId: "noTestUtilsRemoved", data: { name: "Simulate" } }],
+    },
+    // removed utility, aliased
+    {
+      code: `import { renderIntoDocument as rid } from 'react-dom/test-utils';`,
+      errors: [
+        { messageId: "noTestUtilsRemoved", data: { name: "renderIntoDocument" } },
+      ],
+    },
+    // default / namespace imports — the whole module is gone
+    {
+      code: `import TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
+      errors: [{ messageId: "noTestUtilsModule" }],
     },
     {
       code: `import * as TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
-      errors: [
-        { messageId: "noTestUtilsAct" },
-      ],
+      errors: [{ messageId: "noTestUtilsModule" }],
+    },
+    // shadowing doesn't rescue the import itself
+    {
+      code: `import TestUtils from 'react-dom/test-utils'; function useLocal(TestUtils) { TestUtils.act(() => {}); }`,
+      errors: [{ messageId: "noTestUtilsModule" }],
+    },
+    // side-effect import
+    {
+      code: `import 'react-dom/test-utils';`,
+      errors: [{ messageId: "noTestUtilsModule" }],
     },
     // CommonJS destructure — reported, not fixed
     {
       code: `const { act } = require('react-dom/test-utils'); act(() => {});`,
       errors: [{ messageId: "noTestUtilsAct" }],
     },
-    // CommonJS namespace var + member access
+    // CommonJS destructure of removed utilities
+    {
+      code: `const { Simulate, mockComponent } = require('react-dom/test-utils');`,
+      errors: [
+        { messageId: "noTestUtilsRemoved", data: { name: "Simulate" } },
+        { messageId: "noTestUtilsRemoved", data: { name: "mockComponent" } },
+      ],
+    },
+    // CommonJS namespace var
     {
       code: `const TestUtils = require('react-dom/test-utils'); TestUtils.act(() => {});`,
-      errors: [{ messageId: "noTestUtilsAct" }],
+      errors: [{ messageId: "noTestUtilsModule" }],
     },
     // inline require
     {
       code: `require('react-dom/test-utils').act(() => {});`,
       errors: [{ messageId: "noTestUtilsAct" }],
     },
+    {
+      code: `require('react-dom/test-utils').renderIntoDocument(<App />);`,
+      errors: [
+        { messageId: "noTestUtilsRemoved", data: { name: "renderIntoDocument" } },
+      ],
+    },
   ],
 });
+
+// -----------------------------------------------------------------------
+// 10. no-legacy-react-is
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-legacy-react-is", ruleNoLegacyReactIs, {
+  valid: [
+    // surviving react-is APIs
+    `import { isElement } from 'react-is'; isElement(x);`,
+    `import * as ReactIs from 'react-is'; ReactIs.isFragment(x);`,
+    `const { isValidElementType } = require('react-is'); isValidElementType(x);`,
+    // same names from a different module
+    `import { isAsyncMode } from 'not-react-is'; isAsyncMode(x);`,
+    // local identifier coincidence, no react-is binding
+    `const isConcurrentMode = () => false; isConcurrentMode(x);`,
+    // shadowed local is not the imported namespace
+    `import ReactIs from 'react-is'; function useLocal(ReactIs) { ReactIs.isAsyncMode(x); }`,
+  ],
+  invalid: [
+    {
+      code: `import { isConcurrentMode } from 'react-is'; isConcurrentMode(x);`,
+      errors: [{ messageId: "noIsConcurrentMode" }],
+    },
+    // removed import should fail even if unused
+    {
+      code: `import { isAsyncMode } from 'react-is';`,
+      errors: [{ messageId: "noIsAsyncMode" }],
+    },
+    // aliased named import
+    {
+      code: `import { isAsyncMode as iam } from 'react-is'; iam(x);`,
+      errors: [{ messageId: "noIsAsyncMode" }],
+    },
+    // default import member access
+    {
+      code: `import ReactIs from 'react-is'; ReactIs.isConcurrentMode(x);`,
+      errors: [{ messageId: "noIsConcurrentMode" }],
+    },
+    // namespace import member access
+    {
+      code: `import * as ReactIs from 'react-is'; ReactIs.isAsyncMode(x);`,
+      errors: [{ messageId: "noIsAsyncMode" }],
+    },
+    // removed member reference should fail even if not called
+    {
+      code: `import ReactIs from 'react-is'; const check = ReactIs.isConcurrentMode;`,
+      errors: [{ messageId: "noIsConcurrentMode" }],
+    },
+    // destructure from require
+    {
+      code: `const { isConcurrentMode } = require('react-is'); isConcurrentMode(x);`,
+      errors: [{ messageId: "noIsConcurrentMode" }],
+    },
+    // renamed destructure from require
+    {
+      code: `const { isAsyncMode: a } = require('react-is'); a(x);`,
+      errors: [{ messageId: "noIsAsyncMode" }],
+    },
+    // CommonJS namespace var
+    {
+      code: `const ReactIs = require('react-is'); ReactIs.isAsyncMode(x);`,
+      errors: [{ messageId: "noIsAsyncMode" }],
+    },
+    // inline require
+    {
+      code: `require('react-is').isConcurrentMode(x);`,
+      errors: [{ messageId: "noIsConcurrentMode" }],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 11. no-shallow-renderer
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-shallow-renderer", ruleNoShallowRenderer, {
+  valid: [
+    // the correct R19 replacement
+    `import ShallowRenderer from 'react-shallow-renderer';`,
+    `const ShallowRenderer = require('react-shallow-renderer');`,
+    // the base package is a separate (deprecated, not removed) concern
+    `import TestRenderer from 'react-test-renderer';`,
+    // near-miss source string must not match
+    `import Shallow from 'react-test-renderer/shallow-thing';`,
+  ],
+  invalid: [
+    {
+      code: `import ShallowRenderer from 'react-test-renderer/shallow';`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `import ShallowRenderer from 'react-shallow-renderer';`,
+    },
+    // namespace import preserved
+    {
+      code: `import * as SR from 'react-test-renderer/shallow';`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `import * as SR from 'react-shallow-renderer';`,
+    },
+    // double quotes preserved
+    {
+      code: `import SR from "react-test-renderer/shallow";`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `import SR from "react-shallow-renderer";`,
+    },
+    // side-effect import
+    {
+      code: `import 'react-test-renderer/shallow';`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `import 'react-shallow-renderer';`,
+    },
+    // CommonJS require
+    {
+      code: `const ShallowRenderer = require('react-test-renderer/shallow');`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `const ShallowRenderer = require('react-shallow-renderer');`,
+    },
+    // destructured require
+    {
+      code: `const { createRenderer } = require('react-test-renderer/shallow');`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `const { createRenderer } = require('react-shallow-renderer');`,
+    },
+    // inline require
+    {
+      code: `new (require('react-test-renderer/shallow'))();`,
+      errors: [{ messageId: "noShallowRenderer" }],
+      output: `new (require('react-shallow-renderer'))();`,
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 12. no-implicit-ref-callback-return
+// -----------------------------------------------------------------------
+
+ruleTester.run(
+  "no-implicit-ref-callback-return",
+  ruleNoImplicitRefCallbackReturn,
+  {
+    valid: [
+      // block body
+      `const view = <div ref={el => { this.el = el; }} />;`,
+      // empty block body
+      `const view = <div ref={el => {}} />;`,
+      // explicit undefined
+      `const view = <div ref={el => undefined} />;`,
+      // void operator
+      `const view = <div ref={el => void (this.el = el)} />;`,
+      // ref object
+      `const view = <div ref={myRef} />;`,
+      // implicit return is fine on non-ref attributes
+      `const view = <div onClick={e => (count = e)} />;`,
+      // function expressions are out of scope
+      `const view = <div ref={function (el) { self.el = el; }} />;`,
+      // explicit returns in block bodies are out of scope (intentional cleanup)
+      `const view = <div ref={el => { attach(el); return () => detach(el); }} />;`,
+    ],
+    invalid: [
+      // parenthesized assignment — parens removed by the fix
+      {
+        code: `const view = <div ref={el => (this.el = el)} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: `const view = <div ref={el => { this.el = el; }} />;`,
+      },
+      // bare assignment
+      {
+        code: `const view = <div ref={el => this.el = el} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: `const view = <div ref={el => { this.el = el; }} />;`,
+      },
+      // call expression
+      {
+        code: `const view = <li ref={el => list.push(el)} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: `const view = <li ref={el => { list.push(el); }} />;`,
+      },
+      // conditional expression
+      {
+        code: `const view = <div ref={el => el ? attach(el) : detach()} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: `const view = <div ref={el => { el ? attach(el) : detach(); }} />;`,
+      },
+      // sequence expression
+      {
+        code: `const view = <div ref={el => (map.set(id, el), el.focus())} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: `const view = <div ref={el => { map.set(id, el), el.focus(); }} />;`,
+      },
+      // only undefined/void are exempt — null still flagged
+      {
+        code: `const view = <div ref={el => null} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: `const view = <div ref={el => { null; }} />;`,
+      },
+      // comments adjacent to the body suppress the fix
+      {
+        code: `const view = <div ref={el => /* keep */ (this.el = el)} />;`,
+        errors: [{ messageId: "noImplicitRefCallbackReturn" }],
+        output: null,
+      },
+      // multiple refs fixed in one pass
+      {
+        code: `const view = <div><span ref={el => (a = el)} /><em ref={el => (b = el)} /></div>;`,
+        errors: [
+          { messageId: "noImplicitRefCallbackReturn" },
+          { messageId: "noImplicitRefCallbackReturn" },
+        ],
+        output: `const view = <div><span ref={el => { a = el; }} /><em ref={el => { b = el; }} /></div>;`,
+      },
+    ],
+  },
+);
 
 // -----------------------------------------------------------------------
 // summary

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -11,6 +11,7 @@ const ruleNoFactories = require("../rules/no-factories");
 const ruleNoLegacyReactDom = require("../rules/no-legacy-react-dom");
 const ruleNoLegacyReactDomServer = require("../rules/no-legacy-react-dom-server");
 const ruleNoLegacyTestUtilsAct = require("../rules/no-legacy-test-utils-act");
+const ruleNoLegacyTestUtils = require("../rules/no-legacy-test-utils");
 const ruleNoLegacyReactIs = require("../rules/no-legacy-react-is");
 const ruleNoShallowRenderer = require("../rules/no-shallow-renderer");
 const ruleNoImplicitRefCallbackReturn = require("../rules/no-implicit-ref-callback-return");
@@ -78,7 +79,7 @@ describe("plugin api surface", () => {
     assert.ok(plugin.rules && typeof plugin.rules === "object", "plugin.rules exists");
   });
 
-  it("registers all eleven canonical rules", () => {
+  it("registers all twelve canonical rules", () => {
     for (const name of [
       "no-default-props",
       "no-prop-types",
@@ -88,6 +89,7 @@ describe("plugin api surface", () => {
       "no-legacy-react-dom",
       "no-legacy-react-dom-server",
       "no-legacy-test-utils-act",
+      "no-legacy-test-utils",
       "no-legacy-react-is",
       "no-shallow-renderer",
       "no-implicit-ref-callback-return",
@@ -824,6 +826,80 @@ ruleTester.run("no-legacy-test-utils-act", ruleNoLegacyTestUtilsAct, {
   valid: [
     // correct R19 import
     `import { act } from 'react'; act(() => {});`,
+    // unrelated test-utils export still legal (narrow rule; see no-legacy-test-utils)
+    `import { Simulate } from 'react-dom/test-utils'; Simulate.click(node);`,
+    `const TestUtils = require('react-dom/test-utils'); TestUtils.Simulate.click(node);`,
+    // different module
+    `import TestUtils from 'other/test-utils'; TestUtils.act(() => {});`,
+    // local identifier coincidentally named act, no test-utils binding
+    `const act = (fn) => fn(); act(() => {});`,
+    // shadowed local is not the imported namespace
+    `import TestUtils from 'react-dom/test-utils'; function useLocal(TestUtils) { TestUtils.act(() => {}); }`,
+  ],
+  invalid: [
+    // simple named import — fixable
+    {
+      code: `import { act } from 'react-dom/test-utils'; act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act } from 'react'; act(() => {});`,
+    },
+    // aliased named import — alias preserved
+    {
+      code: `import { act as a } from 'react-dom/test-utils'; a(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act as a } from 'react'; a(() => {});`,
+    },
+    // mixed — split into two imports
+    {
+      code: `import { act, Simulate } from 'react-dom/test-utils';`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act } from 'react';\nimport { Simulate } from 'react-dom/test-utils';`,
+    },
+    // default + named — default stays, act moves
+    {
+      code: `import TestUtils, { act } from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+      output: `import { act } from 'react';\nimport TestUtils from 'react-dom/test-utils'; TestUtils.Simulate.click(node);`,
+    },
+    // namespace + act via member access — reported, not fixed
+    {
+      code: `import TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
+      errors: [
+        { messageId: "noTestUtilsAct" },
+      ],
+    },
+    {
+      code: `import * as TestUtils from 'react-dom/test-utils'; TestUtils.act(() => {});`,
+      errors: [
+        { messageId: "noTestUtilsAct" },
+      ],
+    },
+    // CommonJS destructure — reported, not fixed
+    {
+      code: `const { act } = require('react-dom/test-utils'); act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+    },
+    // CommonJS namespace var + member access
+    {
+      code: `const TestUtils = require('react-dom/test-utils'); TestUtils.act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+    },
+    // inline require
+    {
+      code: `require('react-dom/test-utils').act(() => {});`,
+      errors: [{ messageId: "noTestUtilsAct" }],
+    },
+  ],
+});
+
+// -----------------------------------------------------------------------
+// 10. no-legacy-test-utils
+// -----------------------------------------------------------------------
+
+ruleTester.run("no-legacy-test-utils", ruleNoLegacyTestUtils, {
+  valid: [
+    // correct R19 import
+    `import { act } from 'react'; act(() => {});`,
     // the modern replacement for the removed utilities
     `import { render } from '@testing-library/react'; render(<App />);`,
     // different module
@@ -927,7 +1003,7 @@ ruleTester.run("no-legacy-test-utils-act", ruleNoLegacyTestUtilsAct, {
 });
 
 // -----------------------------------------------------------------------
-// 10. no-legacy-react-is
+// 11. no-legacy-react-is
 // -----------------------------------------------------------------------
 
 ruleTester.run("no-legacy-react-is", ruleNoLegacyReactIs, {
@@ -997,7 +1073,7 @@ ruleTester.run("no-legacy-react-is", ruleNoLegacyReactIs, {
 });
 
 // -----------------------------------------------------------------------
-// 11. no-shallow-renderer
+// 12. no-shallow-renderer
 // -----------------------------------------------------------------------
 
 ruleTester.run("no-shallow-renderer", ruleNoShallowRenderer, {
@@ -1056,7 +1132,7 @@ ruleTester.run("no-shallow-renderer", ruleNoShallowRenderer, {
 });
 
 // -----------------------------------------------------------------------
-// 12. no-implicit-ref-callback-return
+// 13. no-implicit-ref-callback-return
 // -----------------------------------------------------------------------
 
 ruleTester.run(


### PR DESCRIPTION
## Summary

An audit of the plugin against the [official React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide) and the v19.0.0 changelog found four uncovered removals plus one fixable behavior change. This PR closes those gaps **without changing the behavior of any existing rule**, so it can ship as a semver-minor release.

### New rules (all opt-in — the plugin has no shared config)

- **`no-legacy-test-utils`** (fixable) — the *entire* `react-dom/test-utils` module is removed in React 19. Flags every binding of the module: named imports of removed utilities (`Simulate`, `renderIntoDocument`, …) point to `@testing-library/react`; namespace/default/CJS bindings and side-effect imports are flagged at the declaration; `act` imports are autofixed to `import { act } from 'react'` (including the mixed-import split). Supersedes `no-legacy-test-utils-act`, which stays untouched (same reports, same locations, existing disable comments keep working) and is documented as the narrow back-compat variant — enable one or the other.
- **`no-shallow-renderer`** (fixable) — `react-test-renderer/shallow` is removed; the import/require source is rewritten to `react-shallow-renderer` (a drop-in — the old entry point re-exported it), preserving quote style.
- **`no-legacy-react-is`** — `isConcurrentMode` and `isAsyncMode` are removed from `react-is` without replacement; covers all the import/require/alias/shadowing forms the sibling rules handle.
- **`no-implicit-ref-callback-return`** (fixable) — React 19 treats a ref callback's return value as a cleanup function, so `ref={el => (this.el = el)}` breaks TypeScript and can change behavior. The fix wraps the body in braces (stripping wrapping parens; suppressed when a comment would be swallowed). Only arrow expression bodies are flagged, matching the official `react/19` codemod; only `undefined`/`void` bodies are exempt.

### Extended existing rule (additive only)

- **`no-legacy-react-dom`** — added the removed `unstable_flushControlled`, `unstable_createEventHandle`, `unstable_renderSubtreeIntoContainer` / `renderSubtreeIntoContainer`, and `unstable_runWithPriority` to the removed-API map; all existing import/require/namespace/alias/shadowing detection applies automatically. New errors only on code using removed APIs — consistent with ESLint's semver policy for minor releases.

### Deliberately out of scope

`useRef()` no-arg and other TypeScript-only changes, `javascript:` URLs (covered by `eslint-plugin-react/no-script-url`), the `react-test-renderer` deprecation (not a removal), and `element.ref` (README already directs users to the official codemod). Render error-handling changes, UMD build removal, and StrictMode/Suspense behavior changes are not statically lintable.

## Test plan

- `npm test`: 213 passed, 0 failed
- API-surface block asserts all 12 canonical rules; the original `no-legacy-test-utils-act` test block is preserved verbatim to pin its unchanged behavior, and the new rules each get full RuleTester blocks including autofix `output` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)